### PR TITLE
Add dummy version to package.json to fix install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sharelatex",
+  "version": "0.0.1",
   "description": "An online collaborative LaTeX editor",
   "dependencies": {
     "rimraf": "~2.2.6",


### PR DESCRIPTION
Without a dummy version, installation fails. I tried both `npm install` and `nmp install .`.

Seems to be what npm documents: https://www.npmjs.org/doc/files/package.json.html

> The most important things in your package.json are the name and version fields. Those are actually required,
