### PR TITLE
Add grunt install to package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Dependencies
 ShareLaTeX should run on OS X and Linux. You need:
 
 * [Node.js](http://nodejs.org/) 0.10 or greater
-* The [grunt](http://gruntjs.com/) command line tools (Run `npm install -g grunt-cli` to install them)
 * A local instance of [Redis](http://redis.io/) (version 2.6 or later) and [MongoDB](http://www.mongodb.org/) running on their standard ports.
 * An up to date version of [TeXLive](https://www.tug.org/texlive/), with the `latexmk` program installed. You need latexmk from TeXLive 2013 (or the later). If you're on an older version, or aren't sure, then the following commands will install the latest version locally:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "sharelatex",
   "description": "An online collaborative LaTeX editor",
+  "scripts": {
+    "preinstall": "npm install -g grunt-cli"
+  }
   "dependencies": {
     "rimraf": "~2.2.6",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git"


### PR DESCRIPTION
One less action for the user to worry about.

Always work because npm is already installed.
