### PR TITLE
Put dependencies before installation procedure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ ShareLaTeX
 
 **[Read more on our blog](https://www.sharelatex.com/blog/2014/02/21/sharelatex-is-now-open-source.html#.UwcnsEJ_ugc)**
 
+Dependencies
+------------
+
+ShareLaTeX should run on OS X and Linux. You need:
+
+* [Node.js](http://nodejs.org/) 0.10 or greater
+* The [grunt](http://gruntjs.com/) command line tools (Run `npm install -g grunt-cli` to install them)
+* A local instance of [Redis](http://redis.io/) (version 2.6 or later) and [MongoDB](http://www.mongodb.org/) running on their standard ports.
+* An up to date version of [TeXLive](https://www.tug.org/texlive/), with the `latexmk` program installed. You need latexmk from TeXLive 2013 (or the later). If you're on an older version, or aren't sure, then the following commands will install the latest version locally:
+
+```bash
+mkdir ~/bin 
+curl http://mirror.physik-pool.tu-berlin.de/tex-archive/support/latexmk/latexmk.pl > ~/bin/latexmk
+chmod a+x ~/bin/latexmk
+export PATH=~/bin:$PATH
+```
+
 Installation
 ------------
 
@@ -44,23 +61,6 @@ grunt run
 ```
 
 ShareLaTeX should now be running at http://localhost:3000.
-
-Dependencies
-------------
-
-ShareLaTeX should run on OS X and Linux. You need:
-
-* [Node.js](http://nodejs.org/) 0.10 or greater
-* The [grunt](http://gruntjs.com/) command line tools (Run `npm install -g grunt-cli` to install them)
-* A local instance of [Redis](http://redis.io/) (version 2.6 or later) and [MongoDB](http://www.mongodb.org/) running on their standard ports.
-* An up to date version of [TeXLive](https://www.tug.org/texlive/), with the `latexmk` program installed. You need latexmk from TeXLive 2013 (or the later). If you're on an older version, or aren't sure, then the following commands will install the latest version locally:
-
-```bash
-mkdir ~/bin 
-curl http://mirror.physik-pool.tu-berlin.de/tex-archive/support/latexmk/latexmk.pl > ~/bin/latexmk
-chmod a+x ~/bin/latexmk
-export PATH=~/bin:$PATH
-```
 
 Config
 ------


### PR DESCRIPTION
It is sad to arrive at the end of the installation only discover that you have missing dependencies.

First we should tell people to install those dependencies. 
