### PR TITLE
Remove latexmk install instructions from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,7 @@ ShareLaTeX should run on OS X and Linux. You need:
 * [Node.js](http://nodejs.org/) 0.10 or greater
 * The [grunt](http://gruntjs.com/) command line tools (Run `npm install -g grunt-cli` to install them)
 * A local instance of [Redis](http://redis.io/) (version 2.6 or later) and [MongoDB](http://www.mongodb.org/) running on their standard ports.
-* An up to date version of [TeXLive](https://www.tug.org/texlive/), with the `latexmk` program installed. You need latexmk from TeXLive 2013 (or the later). If you're on an older version, or aren't sure, then the following commands will install the latest version locally:
-
-```bash
-mkdir ~/bin 
-curl http://mirror.physik-pool.tu-berlin.de/tex-archive/support/latexmk/latexmk.pl > ~/bin/latexmk
-chmod a+x ~/bin/latexmk
-export PATH=~/bin:$PATH
-```
+* [TeXLive](https://www.tug.org/texlive/) 2013 or later with the `latexmk` program installed.
 
 Config
 ------


### PR DESCRIPTION
Since cross plaftorm multiline npm/node install rules should not be on the README, the same should go for latexmk to reduce noise.

We can add this to the Wiki instead.
