### PR TITLE
Added "shouldSmokeTest" settings flag.

### DIFF
--- a/config/settings.development.coffee.example
+++ b/config/settings.development.coffee.example
@@ -262,7 +262,7 @@ module.exports =
 	# Provide log in credentials and a project to be able to run
 	# some basic smoke tests to check the core functionality.
 
-	shouldSmokeTest: true
+	shouldSmokeTest: false
 	# smokeTest:
 	# 	user: ""
 	# 	password: ""


### PR DESCRIPTION
The “shouldSmokeTest” flag allows a user to activate or deactivate
smoke testing from the user configuration. The default value is “true”
and will not change pre-check-in behavior.
