### PR TITLE
Add ability to specify interface to bind to

### DIFF
--- a/config/settings.development.coffee.example
+++ b/config/settings.development.coffee.example
@@ -121,6 +121,12 @@ module.exports =
 	# address and http/https protocol information.
 	behindProxy: false
 
+	# If you are running ShareLaTeX behind a proxy or you are running a local 
+	# installation purely for development purposes you may want to bind the
+	# http server to a specific interface/host, or just localhost.
+	# By default, the http server will bind to all interfaces.
+	interface: "0.0.0.0"
+
 	# Sending Email
 	# -------------
 	#


### PR DESCRIPTION
By default nodejs listens to all hosts. This patch adds the config option to specify the hosts to listen too. The default behaviour is not changed; i.e. nodejs listens to all hosts/interfaces.
