### PR TITLE
Changed chdir to cd for changing directories

### DIFF
--- a/package/upstart/sharelatex-chat
+++ b/package/upstart/sharelatex-chat
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-clsi
+++ b/package/upstart/sharelatex-clsi
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-docstore
+++ b/package/upstart/sharelatex-docstore
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-document-updater
+++ b/package/upstart/sharelatex-document-updater
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-filestore
+++ b/package/upstart/sharelatex-filestore
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-spelling
+++ b/package/upstart/sharelatex-spelling
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-tags
+++ b/package/upstart/sharelatex-tags
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-template
+++ b/package/upstart/sharelatex-template
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-track-changes
+++ b/package/upstart/sharelatex-track-changes
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script

--- a/package/upstart/sharelatex-web
+++ b/package/upstart/sharelatex-web
@@ -23,6 +23,6 @@ script
     LATEX_PATH=/usr/local/texlive/2014/bin/x86_64-linux
 
     echo $$ > /var/run/sharelatex-$SERVICE.pid
-    chdir /var/www/sharelatex/$SERVICE
+    cd /var/www/sharelatex/$SERVICE
     exec sudo -u $USER -g $GROUP env SHARELATEX_CONFIG=$SHARELATEX_CONFIG NODE_ENV=production PATH=$PATH:$LATEX_PATH $NODE app.js >> /var/log/sharelatex/$SERVICE.log 2>&1
 end script


### PR DESCRIPTION
`chdir` is the C command for changing directories (from `unistd.h`). Most unix shells alias this command to `cd`, but some don't - for example RHEL. This pull request replaces the use of `chdir` with `cd`.
