### PR TITLE
Add a missing parameter to OneTimeTokenHandler.getNewToken

### DIFF
--- a/tasks/CreateAndDestoryUsers.coffee
+++ b/tasks/CreateAndDestoryUsers.coffee
@@ -21,7 +21,7 @@ module.exports = (grunt) ->
 			user.save (error) ->
 				throw error if error?
 				ONE_WEEK = 7 * 24 * 60 * 60 # seconds
-				OneTimeTokenHandler.getNewToken user._id, { expiresIn: ONE_WEEK }, (err, token)->
+				OneTimeTokenHandler.getNewToken 'password', user._id, { expiresIn: ONE_WEEK }, (err, token)->
 					return next(err) if err?
 					
 					console.log ""


### PR DESCRIPTION
Creating a new admin user from the command line doesn't work because the first argument is missing.