### PR TITLE
Switch install-services from grunt to npm run

### DIFF
--- a/bin/install-services
+++ b/bin/install-services
@@ -20,6 +20,6 @@ grep 'name:' config/services.js | \
 		type -t nvm && nvm use
 		echo '  installing Dependencies'
 		npm install
-		grunt install
+		npm run compile:all
 		popd
 	done


### PR DESCRIPTION
It seems to me that that's the way things are run now.