### PR TITLE
Update east to 1.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,28 +4,33 @@
   "dependencies": {
     "async": {
       "version": "0.9.2",
-      "from": "async@>=0.9.0 <0.10.0",
+      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
     },
     "bson": {
       "version": "1.0.4",
-      "from": "bson@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
     },
     "coffee-script": {
       "version": "1.12.7",
-      "from": "coffee-script@>=1.11.1 <2.0.0",
+      "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
     },
     "east": {
-      "version": "0.5.7",
-      "from": "east@0.5.7",
-      "resolved": "http://registry.npmjs.org/east/-/east-0.5.7.tgz",
+      "version": "1.0.0",
+      "from": "east@1.0.0",
+      "resolved": "https://registry.npmjs.org/east/-/east-1.0.0.tgz",
       "dependencies": {
+        "callbackify": {
+          "version": "1.1.0",
+          "from": "callbackify@1.1.0",
+          "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz"
+        },
         "commander": {
           "version": "2.9.0",
           "from": "commander@2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
@@ -37,157 +42,218 @@
         "expressionify": {
           "version": "0.9.3",
           "from": "expressionify@0.9.3",
-          "resolved": "http://registry.npmjs.org/expressionify/-/expressionify-0.9.3.tgz"
+          "resolved": "https://registry.npmjs.org/expressionify/-/expressionify-0.9.3.tgz"
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "from": "fs-extra@5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.2.0",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz"
+            },
+            "jsonfile": {
+              "version": "4.0.0",
+              "from": "jsonfile@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz"
+            },
+            "universalify": {
+              "version": "0.1.2",
+              "from": "universalify@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
+            }
+          }
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "from": "p-each-series@1.0.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+          "dependencies": {
+            "p-reduce": {
+              "version": "1.0.0",
+              "from": "p-reduce@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz"
+            }
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "from": "p-map@1.2.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz"
+        },
+        "p-props": {
+          "version": "1.2.0",
+          "from": "p-props@1.2.0",
+          "resolved": "https://registry.npmjs.org/p-props/-/p-props-1.2.0.tgz"
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "from": "p-timeout@2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "dependencies": {
+            "p-finally": {
+              "version": "1.0.0",
+              "from": "p-finally@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
         },
         "progress": {
           "version": "1.1.8",
           "from": "progress@1.1.8",
           "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
-        "twostep": {
-          "version": "0.4.2",
-          "from": "twostep@0.4.2",
-          "resolved": "http://registry.npmjs.org/twostep/-/twostep-0.4.2.tgz"
+        "underscore": {
+          "version": "1.9.0",
+          "from": "underscore@1.9.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz"
         }
       }
     },
     "east-mongo": {
       "version": "0.3.3",
-      "from": "east-mongo@0.3.3",
+      "from": "http://registry.npmjs.org/east-mongo/-/east-mongo-0.3.3.tgz",
       "resolved": "http://registry.npmjs.org/east-mongo/-/east-mongo-0.3.3.tgz"
     },
     "grunt-shell": {
       "version": "1.3.1",
-      "from": "grunt-shell@>=1.1.1 <2.0.0",
+      "from": "http://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.1.tgz",
       "resolved": "http://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "npm-run-path": {
           "version": "1.0.0",
-          "from": "npm-run-path@>=1.0.0 <2.0.0",
+          "from": "http://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
           "resolved": "http://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
           "dependencies": {
             "path-key": {
               "version": "1.0.0",
-              "from": "path-key@>=1.0.0 <2.0.0",
+              "from": "http://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
               "resolved": "http://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         }
       }
     },
     "load-grunt-config": {
       "version": "0.19.2",
-      "from": "load-grunt-config@>=0.19.2 <0.20.0",
+      "from": "http://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.19.2.tgz",
       "resolved": "http://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.19.2.tgz",
       "dependencies": {
         "cson": {
           "version": "3.0.2",
-          "from": "cson@>=3.0.2 <3.1.0",
+          "from": "http://registry.npmjs.org/cson/-/cson-3.0.2.tgz",
           "resolved": "http://registry.npmjs.org/cson/-/cson-3.0.2.tgz",
           "dependencies": {
             "cson-parser": {
               "version": "1.3.5",
-              "from": "cson-parser@>=1.0.6 <2.0.0",
+              "from": "http://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
               "resolved": "http://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz"
             },
             "extract-opts": {
               "version": "3.3.1",
-              "from": "extract-opts@>=3.0.1 <4.0.0",
+              "from": "http://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
               "resolved": "http://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
               "dependencies": {
                 "eachr": {
                   "version": "3.2.0",
-                  "from": "eachr@>=3.2.0 <4.0.0",
+                  "from": "http://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
                   "resolved": "http://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz"
                 },
                 "editions": {
                   "version": "1.3.4",
-                  "from": "editions@>=1.1.1 <2.0.0",
+                  "from": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
                   "resolved": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz"
                 },
                 "typechecker": {
                   "version": "4.4.1",
-                  "from": "typechecker@>=4.3.0 <5.0.0",
+                  "from": "http://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz"
                 }
               }
             },
             "requirefresh": {
               "version": "2.1.0",
-              "from": "requirefresh@>=2.0.0 <3.0.0",
+              "from": "http://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz",
               "resolved": "http://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz",
               "dependencies": {
                 "editions": {
                   "version": "1.3.4",
-                  "from": "editions@>=1.1.1 <2.0.0",
+                  "from": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
                   "resolved": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz"
                 }
               }
             },
             "safefs": {
               "version": "4.1.0",
-              "from": "safefs@>=4.0.0 <5.0.0",
+              "from": "http://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
               "resolved": "http://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
               "dependencies": {
                 "editions": {
                   "version": "1.3.4",
-                  "from": "editions@>=1.1.1 <2.0.0",
+                  "from": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
                   "resolved": "http://registry.npmjs.org/editions/-/editions-1.3.4.tgz"
                 },
                 "graceful-fs": {
                   "version": "4.1.11",
-                  "from": "graceful-fs@>=4.1.4 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 }
               }
@@ -196,44 +262,44 @@
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.15 <5.1.0",
+          "from": "http://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "http://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -242,107 +308,107 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "jit-grunt": {
           "version": "0.10.0",
-          "from": "jit-grunt@>=0.10.0 <0.11.0",
+          "from": "http://registry.npmjs.org/jit-grunt/-/jit-grunt-0.10.0.tgz",
           "resolved": "http://registry.npmjs.org/jit-grunt/-/jit-grunt-0.10.0.tgz"
         },
         "js-yaml": {
           "version": "3.4.6",
-          "from": "js-yaml@>=3.4.3 <3.5.0",
+          "from": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
           "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
-              "from": "argparse@>=1.0.2 <2.0.0",
+              "from": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.3",
-              "from": "esprima@>=2.6.0 <3.0.0",
+              "from": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
               "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
             },
             "inherit": {
               "version": "2.2.6",
-              "from": "inherit@>=2.2.2 <3.0.0",
+              "from": "http://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz",
               "resolved": "http://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz"
             }
           }
         },
         "load-grunt-tasks": {
           "version": "3.3.0",
-          "from": "load-grunt-tasks@>=3.3.0 <3.4.0",
+          "from": "http://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
           "resolved": "http://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
           "dependencies": {
             "arrify": {
               "version": "1.0.1",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
             },
             "multimatch": {
               "version": "2.1.0",
-              "from": "multimatch@>=2.0.0 <3.0.0",
+              "from": "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
               "resolved": "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
               "dependencies": {
                 "array-differ": {
                   "version": "1.0.0",
-                  "from": "array-differ@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
                 },
                 "array-union": {
                   "version": "1.0.2",
-                  "from": "array-union@>=1.0.1 <2.0.0",
+                  "from": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                   "dependencies": {
                     "array-uniq": {
                       "version": "1.0.3",
-                      "from": "array-uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -353,27 +419,27 @@
             },
             "pkg-up": {
               "version": "1.0.0",
-              "from": "pkg-up@>=1.0.0 <2.0.0",
+              "from": "http://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
               "resolved": "http://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "resolved": "http://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "from": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "http://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -388,37 +454,37 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "mongodb": {
       "version": "2.2.34",
-      "from": "mongodb@>=2.2.34 <3.0.0",
+      "from": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
       "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.2.1",
-          "from": "es6-promise@3.2.1",
+          "from": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
           "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
         },
         "mongodb-core": {
           "version": "2.1.18",
-          "from": "mongodb-core@2.1.18",
+          "from": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
           "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
           "dependencies": {
             "require_optional": {
               "version": "1.0.1",
-              "from": "require_optional@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.5.0",
-                  "from": "semver@>=5.1.0 <6.0.0",
+                  "from": "http://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
                   "resolved": "http://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
-                  "from": "resolve-from@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                 }
               }
@@ -427,49 +493,49 @@
         },
         "readable-stream": {
           "version": "2.2.7",
-          "from": "readable-stream@2.2.7",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "1.0.3",
-              "from": "string_decoder@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.0 <5.2.0",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                 }
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
@@ -478,132 +544,132 @@
     },
     "mongojs": {
       "version": "2.4.0",
-      "from": "mongojs@2.4.0",
+      "from": "http://registry.npmjs.org/mongojs/-/mongojs-2.4.0.tgz",
       "resolved": "http://registry.npmjs.org/mongojs/-/mongojs-2.4.0.tgz",
       "dependencies": {
         "each-series": {
           "version": "1.0.0",
-          "from": "each-series@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz"
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@>=1.3.2 <2.0.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             }
           }
         },
         "parse-mongo-url": {
           "version": "1.1.1",
-          "from": "parse-mongo-url@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz"
         },
         "readable-stream": {
           "version": "2.3.3",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.3 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "from": "safe-buffer@>=5.1.1 <5.2.0",
+              "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
             },
             "string_decoder": {
               "version": "1.0.3",
-              "from": "string_decoder@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "thunky": {
           "version": "0.1.0",
-          "from": "thunky@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
         },
         "to-mongodb-core": {
           "version": "2.0.0",
-          "from": "to-mongodb-core@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/to-mongodb-core/-/to-mongodb-core-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/to-mongodb-core/-/to-mongodb-core-2.0.0.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "redis": {
       "version": "2.8.0",
-      "from": "redis@>=2.6.2 <3.0.0",
+      "from": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "dependencies": {
         "double-ended-queue": {
           "version": "2.1.0-0",
-          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+          "from": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
           "version": "1.3.1",
-          "from": "redis-commands@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
         },
         "redis-parser": {
           "version": "2.6.0",
-          "from": "redis-parser@>=2.6.0 <3.0.0",
+          "from": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz"
         }
       }
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@>=2.2.6 <2.3.0",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "settings-sharelatex": {
       "version": "1.0.0",
-      "from": "git+https://github.com/sharelatex/settings-sharelatex.git",
+      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#b4fb8404c5de571d029bf4c29e96a60b21206f94",
       "resolved": "git+https://github.com/sharelatex/settings-sharelatex.git#b4fb8404c5de571d029bf4c29e96a60b21206f94",
       "dependencies": {
         "coffee-script": {
           "version": "1.6.0",
-          "from": "coffee-script@1.6.0",
+          "from": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz",
           "resolved": "http://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@>=1.7.0 <2.0.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "async": "^0.9.0",
     "bson": "^1.0.4",
     "coffee-script": "^1.11.1",
-    "east": "0.5.7",
+    "east": "1.0.0",
     "east-mongo": "0.3.3",
     "grunt-shell": "^1.1.1",
     "load-grunt-config": "^0.19.2",


### PR DESCRIPTION
Version 1.0.0 comes with many internal improvements (including that `migrate` and `rollback` functions now could return a promise/be `async` function) and backward compatible with version 0.5.x