### PR TITLE
Added mongo healthcheck to docker-compose

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
     sharelatex:
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
-version: '2'
+version: '2.2'
 services:
     sharelatex:
         restart: always
         image: sharelatex/sharelatex
         container_name: sharelatex
         depends_on:
-            - mongo
-            - redis
+            mongo:
+                condition: service_healthy
+            redis:
+                condition: service_started
         privileged: true
         ports:
             - 80:80
@@ -93,6 +95,11 @@ services:
             - 27017
         volumes:
             - ~/mongo_data:/data/db
+        healthcheck:
+            test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+            interval: 10s
+            timeout: 10s
+            retries: 5
 
     redis:
         restart: always


### PR DESCRIPTION
This prevents the server from starting before mongo is ready, in which case migrations may not work.