### PR TITLE
Fixed misspelling in migration script

### DIFF
--- a/migrations/9_create_user_emails_array.js
+++ b/migrations/9_create_user_emails_array.js
@@ -22,7 +22,7 @@ const initUserEmailsAttribute = (user, callback) => {
 }
 
 const updateAllUsersEmailsAttribute = (users, callback) => {
-  console.log(`updating ${user.length} users`)
+  console.log(`updating ${users.length} users`)
   async.eachSeries(users, initUserEmailsAttribute, callback)
 }
 


### PR DESCRIPTION
Tested with a local version of Overleaf Community, it's all ok now.