### PR TITLE
Added explicit reference to Server Pro image in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2.2'
 services:
     sharelatex:
         restart: always
+        # Server Pro users: 
+        # image: quay.io/sharelatex/sharelatex-pro
         image: sharelatex/sharelatex
         container_name: sharelatex
         depends_on:


### PR DESCRIPTION
Addresses some concern over users confused following instructions pointing to `docker-compose.yml` as an example.