### PR TITLE
Remove make targets in web

### DIFF
--- a/bin/compile-services
+++ b/bin/compile-services
@@ -10,8 +10,6 @@ grep 'name:' config/services.js | \
 		echo "Compiling Service $service"
 		case $service in 
 			web)
-				make compile_full
-				make minify
 				npm run webpack:production
 				;;
 			chat)


### PR DESCRIPTION
Since css compilation was moved into webpack, and the corresponding make rule removed, this script would fail with an error. This removes the offending calls to make.