### PR TITLE
Remove unnecessary compilation after webpack migration

### DIFF
--- a/bin/compile-services
+++ b/bin/compile-services
@@ -9,9 +9,7 @@ grep 'name:' config/services.js | \
 		pushd $service
 		echo "Compiling Service $service"
 		case $service in 
-			web)
-				make compile_full
-				make minify
+			web)			
 				npm run webpack:production
 				;;
 			chat)


### PR DESCRIPTION
`make minify` and `make compile_full` were removed in https://github.com/overleaf/web-internal/commit/d0a24abee08cebc3feb88a3db72016a0d56b063c, this PR removes its Overleaf CE counterpart.