### PR TITLE
Updated location of synctex path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
             # SANDBOXED_COMPILES_SIBLING_CONTAINERS: 'true'
             # SANDBOXED_COMPILES_HOST_DIR: '/var/sharelatex_data/data/compiles'
-            # SYNCTEX_BIN_HOST_PATH: '/var/sharelatex_data/synctex'
+            # SYNCTEX_BIN_HOST_PATH: '/var/sharelatex_data/bin/synctex'
 
             # DOCKER_RUNNER: 'false'
 


### PR DESCRIPTION
There was a mismatch between compose file and docs: https://github.com/overleaf/overleaf/wiki/Server-Pro:-sandboxed-compiles#mapping-the-location-of-synctex-in-the-host.

One customer had an issue, I think due to this.

