### PR TITLE
Removed compile:all from filestore and notifications services

### DIFF
--- a/bin/compile-services
+++ b/bin/compile-services
@@ -12,7 +12,7 @@ grep 'name:' config/services.js | \
 			web)
 				npm run webpack:production
 				;;
-			chat)
+			chat|filestore|notifications)
 				echo "$service doesn't require a compilation"
 				;;	
 			*)


### PR DESCRIPTION
Removes `compile:all` stage, which breaks CE/ServerPro builds after decaffeination.