### PR TITLE
Comment out the docker socket mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,11 @@ services:
             - redis
         volumes:
             - ~/sharelatex_data:/var/lib/sharelatex
-            - /var/run/docker.sock:/var/run/docker.sock
+            ########################################################################
+            ####  Server Pro: Un-comment the following line to mount the docker ####
+            ####             socket, required for Sibling Containers to work    ####
+            ########################################################################
+            # - /var/run/docker.sock:/var/run/docker.sock
         environment:
 
             SHARELATEX_APP_NAME: Overleaf Community Edition


### PR DESCRIPTION
And add a note for server-pro users to un-comment the line if they want to use sibling containers.