### PR TITLE
Added 'currentImageName' setting plus migration

### DIFF
--- a/migrations/11_set_project_image_name.js
+++ b/migrations/11_set_project_image_name.js
@@ -10,6 +10,8 @@ exports.migrate = (client, done) => {
         return done()
     }
 
+    console.log(`>> Setting 'imageName' = ${Settings.currentImageName}`)
+
     db.projects.update(
         { imageName: { $exists: false } },
         { $set: { imageName: Settings.currentImageName } },

--- a/migrations/11_set_project_image_name.js
+++ b/migrations/11_set_project_image_name.js
@@ -1,6 +1,6 @@
 const Settings = require('settings-sharelatex')
 const mongojs = require('mongojs')
-const db = mongojs(Settings.mongo.url, ['users'])
+const db = mongojs(Settings.mongo.url, ['projects'])
 
 exports.migrate = (client, done) => {
     console.log(`>> Setting 'imageName' in projects`)

--- a/migrations/11_set_project_image_name.js
+++ b/migrations/11_set_project_image_name.js
@@ -1,0 +1,21 @@
+const Settings = require('settings-sharelatex')
+const mongojs = require('mongojs')
+const db = mongojs(Settings.mongo.url, ['users'])
+
+exports.migrate = (client, done) => {
+    console.log(`>> Setting 'imageName' in projects`)
+
+    if (!Settings.currentImageName) {
+        console.log(`>> 'currentImageName' is not defined, no projects updated`)
+        return done()
+    }
+
+    db.projects.update(
+        { imageName: { $exists: false } },
+        { $set: { imageName: Settings.currentImageName } },
+        { multi: true },
+        done
+    )
+}
+
+exports.rollback = (client, done) => done()

--- a/settings.coffee
+++ b/settings.coffee
@@ -194,6 +194,9 @@ settings =
 			www: {lngCode:process.env["SHARELATEX_SITE_LANGUAGE"] or "en", url: siteUrl}
 		defaultLng: process.env["SHARELATEX_SITE_LANGUAGE"] or "en"
 
+	currentImageName: process.env["TEX_LIVE_DOCKER_IMAGE"]
+	importedImageName: process.env["TEX_LIVE_DOCKER_IMAGE"]
+
 	apis:
 		web:
 			url: "http://localhost:3000"

--- a/settings.coffee
+++ b/settings.coffee
@@ -195,7 +195,6 @@ settings =
 		defaultLng: process.env["SHARELATEX_SITE_LANGUAGE"] or "en"
 
 	currentImageName: process.env["TEX_LIVE_DOCKER_IMAGE"]
-	importedImageName: process.env["TEX_LIVE_DOCKER_IMAGE"]
 
 	apis:
 		web:


### PR DESCRIPTION
Not having `Settings.currentImageName` defined prevents `imageName` from being set in a project. Therefore, when updating TexLive,  the project will be using the newest version instead of sticking to the version used when it was created:

https://github.com/overleaf/web/blob/master/app/src/Features/Project/ProjectCreationHandler.js#L108-L113

A new migration sets `imageName` to the current active image, which doesn't interfere with how things work at the moment, paving the ground for subsequent TexLive upgrades. There's no really a way to find the original image for which the project was created.