### PR TITLE
Making luatex compiles work again

### DIFF
--- a/init_scripts/00_make_sharelatex_data_dirs.sh
+++ b/init_scripts/00_make_sharelatex_data_dirs.sh
@@ -28,6 +28,8 @@ chown www-data:www-data /var/lib/sharelatex/tmp/uploads
 mkdir -p /var/lib/sharelatex/tmp/dumpFolder
 chown www-data:www-data /var/lib/sharelatex/tmp/dumpFolder
 
+chown www-data:www-data /var/www/
+
 if [ ! -e "/var/lib/sharelatex/data/db.sqlite" ]; then
        touch /var/lib/sharelatex/data/db.sqlite
 fi


### PR DESCRIPTION
Rechowning www-data home directory /var/www/ by partially reverting commit [e25d559 in overleaf/docker-image](https://github.com/overleaf/docker-image/pull/119/commits/e25d5593290705ad4167aa019863cb768afcd8b7) to enable automatic creation of `.texlive2019` subdirectory to make luatex compiles working again

hopefully fixes #695: I wasn't able to locally build the docker image to test. I'm not keen on investing more time for a one-liner. Please, anyone who has a working setup, test this fix. See #695 for details.