### PR TITLE
fix minor bug of compile-services

### DIFF
--- a/bin/compile-services
+++ b/bin/compile-services
@@ -12,7 +12,7 @@ grep 'name:' config/services.js | \
 			web)
 				npm run webpack:production
 				;;
-			chat|filestore|notifications|tags)
+			contacts|docstore|chat|filestore|clsi|notifications|tags|track-changes)
 				echo "$service doesn't require a compilation"
 				;;	
 			*)


### PR DESCRIPTION
Hello, I am trying to build overleaf images via ```make build-base``` and ```make build-community```, and then find this minor bug. Errors will be reported when doing ```make build-community``` as follows:
```
"Compiling Service clsi", 
missing script: compile:all
```

The reason is running the script of "compile:all" is unnecessary for "clsi", "docstore" and so on. 

And thanks for your open-sourced, it's pretty good and works well in my team now.