### PR TITLE
Add allowedImageNames Setting from ENV Vars

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -537,6 +537,18 @@ if process.env["SHARELATEX_ELASTICSEARCH_URL"]?
 	settings.references.elasticsearch =
 			host: process.env["SHARELATEX_ELASTICSEARCH_URL"]
 
+# TeX Live Images
+# -----------
+if process.env["ALL_TEX_LIVE_DOCKER_IMAGES"]?
+	allTexLiveDockerImages = process.env["ALL_TEX_LIVE_DOCKER_IMAGES"].split(',')
+if process.env["ALL_TEX_LIVE_DOCKER_IMAGE_NAMES"]?
+	allTexLiveDockerImageNames = process.env["ALL_TEX_LIVE_DOCKER_IMAGE_NAMES"].split(',')
+if allTexLiveDockerImages?
+	settings.allowedImageNames = []
+	for fullImageName, index in allTexLiveDockerImages
+		imageName = Path.basename(fullImageName)
+		imageDesc = if allTexLiveDockerImageNames? then allTexLiveDockerImageNames[index] else imageName
+		settings.allowedImageNames.push({ imageName, imageDesc })
 
 # With lots of incoming and outgoing HTTP connections to different services,
 # sometimes long running, it is a good idea to increase the default number


### PR DESCRIPTION
### Description

In order to allow users to change a project's Tex Live version, we need the `allowedImageNames` to be set with the available TeX Live versions.

This uses the existing `ALL_TEX_LIVE_DOCKER_IMAGES` ENV var to create the list, optionally using a new `ALL_TEX_LIVE_DOCKER_IMAGE_NAMES` ENV var to display user-friendly image names.

#### Screenshots

##### With `ALL_TEX_LIVE_DOCKER_IMAGE_NAMES`:
```
ALL_TEX_LIVE_DOCKER_IMAGES="quay.io/sharelatex/texlive-full:2016.1,quay.io/sharelatex/texlive-full:2017.1"
ALL_TEX_LIVE_DOCKER_IMAGE_NAMES="2016 (legacy),2017 (current)"
```
<img width="265" alt="Screenshot 2020-04-08 at 14 02 24" src="https://user-images.githubusercontent.com/1547215/78782985-34c24b00-79a3-11ea-8f9f-68b9ace85b14.png">

##### Without `ALL_TEX_LIVE_DOCKER_IMAGE_NAMES`:
```
ALL_TEX_LIVE_DOCKER_IMAGES="quay.io/sharelatex/texlive-full:2016.1,quay.io/sharelatex/texlive-full:2017.1"
```
<img width="285" alt="Screenshot 2020-04-08 at 14 05 43" src="https://user-images.githubusercontent.com/1547215/78782989-355ae180-79a3-11ea-99a7-90dc67a3abdf.png">

#### Related Issues / PRs

Part of https://github.com/overleaf/issues/issues/2754

### Review

This should only impact installations with Sibling Containers. Is that correct @mserranom ?