### PR TITLE
Remove compilation step from document-updater

### DIFF
--- a/bin/compile-services
+++ b/bin/compile-services
@@ -12,7 +12,7 @@ grep 'name:' config/services.js | \
 			web)
 				npm run webpack:production
 				;;
-			real-time|document-updater)
+			real-time)
 				npm run compile:all
 				;;	
 			*)


### PR DESCRIPTION
## Description

Remove `compile:all` step, which is not needed after https://github.com/overleaf/document-updater/pull/107