### PR TITLE
Restrict Redis version to 5.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
 
     redis:
         restart: always
-        image: redis
+        image: redis:5.0.0
         container_name: redis
         expose:
             - 6379


### PR DESCRIPTION
Restrict redis version to 5.0.0

## Description
<!-- Goal of the pull request -->
Restrict Redis version to 5.0.0 so that sharelatex will successfully connect to the redis server.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
#734 #735 

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
