### PR TITLE
Set TEXMFVAR to a writable location

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -7,6 +7,11 @@ FROM phusion/baseimage:0.11
 ENV baseDir .
 
 
+# Makes sure LuaTex cache is writable
+# -----------------------------------
+ENV TEXMFVAR=/var/lib/sharelatex/tmp/texmf-var
+
+
 # Install dependencies
 # --------------------
 RUN apt-get update \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,6 @@ services:
             # Disables email confirmation requirement
             EMAIL_CONFIRMATION_DISABLED: 'true'
 
-            # temporary fix for LuaLaTex compiles
-            # see https://github.com/overleaf/overleaf/issues/695
-            TEXMFVAR: /var/lib/sharelatex/tmp/texmf-var
-
             ## Set for SSL via nginx-proxy
             #VIRTUAL_HOST: 103.112.212.22
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,13 @@ services:
 
             # Enables Thumbnail generation using ImageMagick
             ENABLE_CONVERSIONS: 'true'
-            
+
             # Disables email confirmation requirement
             EMAIL_CONFIRMATION_DISABLED: 'true'
+
+            # temporary fix for LuaLaTex compiles
+            # see https://github.com/overleaf/overleaf/issues/695
+            TEXMFVAR: /var/lib/sharelatex/tmp/texmf-var
 
             ## Set for SSL via nginx-proxy
             #VIRTUAL_HOST: 103.112.212.22


### PR DESCRIPTION
## Description

Moves setting `TEXMFVAR` from `docker-compose.yml` to the `Dockerfile` in preparation for a new release.

It was originally added as a temporary solution for backwards compatibility in https://github.com/overleaf/overleaf/pull/726.


## Related issues / Pull Requests

https://github.com/overleaf/overleaf/issues/695
https://github.com/overleaf/overleaf/pull/726
