### PR TITLE
added 'OPTIMISE_PDF' environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ ENV WEB_API_USER "sharelatex"
 
 ENV SHARELATEX_APP_NAME "Overleaf Community Edition"
 
+ENV OPTIMISE_PDF "true"
+
 
 EXPOSE 80
 

--- a/settings.coffee
+++ b/settings.coffee
@@ -22,6 +22,9 @@ TMP_DIR = '/var/lib/sharelatex/tmp'
 
 settings =
 
+	clsi:
+		optimiseInDocker: process.env['OPTIMISE_PDF'] == 'true'
+
 	brandPrefix: ""
 
 	allowAnonymousReadAndWriteSharing:


### PR DESCRIPTION
## Description

`clsi` performs an optimisation in the generated PDF which in some cases breaks PDF/A validation.

https://github.com/overleaf/clsi/blob/eb2e84df9b5a71afbd709587848d19cfe85f91bb/app/js/OutputCacheManager.js#L356

This environment variable allows disabling that optimisation step.

