### PR TITLE
Removed privileged mode from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
                 condition: service_healthy
             redis:
                 condition: service_started
-        privileged: true
         ports:
             - 80:80
         links:


### PR DESCRIPTION
## Description

Run some tests, `privileged` mode is not needed to run sandboxed compiles.

Fixes https://github.com/overleaf/overleaf/issues/727