### PR TITLE
Set tag '5' for redis image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
 
     redis:
         restart: always
-        image: redis:5.0.0
+        image: redis:5
         container_name: redis
         expose:
             - 6379


### PR DESCRIPTION
## Description

Sets the tag for `redis` image to `5` to allow minor and patch versions to be consumed by the compose file, as suggested in https://github.com/overleaf/overleaf/pull/737#issuecomment-635909495.