### PR TITLE
Hotfix 2.4.1

### DIFF
--- a/hotfix/2.4.1/Dockerfile
+++ b/hotfix/2.4.1/Dockerfile
@@ -1,0 +1,6 @@
+FROM sharelatex/sharelatex:2.4.0
+
+
+# Patch: Fixes missing dependencies on web startup (https://github.com/overleaf/overleaf/issues/767)
+RUN cd /var/www/sharelatex/web && \
+    npm install i18next@^19.6.3 i18next-fs-backend@^1.0.7 i18next-http-middleware@^3.0.2


### PR DESCRIPTION
Fixes https://github.com/overleaf/overleaf/issues/767

Tested locally, `web` doesn't error on startup and app loads successfully.