### PR TITLE
[misc] add the dependabot config of the buildscripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # Docker images use the branch name and do not support slashes in tags
+      # https://github.com/overleaf/google-ops/issues/822
+      # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#pull-request-branch-nameseparator
+      separator: "-"
+
+    # Block informal upgrades -- security upgrades use a separate queue.
+    # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### Description

Fixes CI for https://github.com/overleaf/overleaf/pull/763 https://github.com/overleaf/overleaf/pull/775

Our CI is pushing docker image tags with the branch name as part of it. docker tags must not contain any slashes, so all builds with a slash in the branch name fail. Dependabot uses slashes in the default config and this PR adjust them to hyphen.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3350
https://github.com/overleaf/dev-environment/pull/371

#### Potential Impact

None for CE/Server PRO.
