### PR TITLE
[misc] keep up with web changes -- add waitForDb wrapper for tasks

### DIFF
--- a/tasks/CreateAndDestoryUsers.coffee
+++ b/tasks/CreateAndDestoryUsers.coffee
@@ -9,31 +9,33 @@ module.exports = (grunt) ->
 			process.exit(1)
 
 		settings = require "settings-sharelatex"
+		mongodb = require "../web/app/src/infrastructure/mongodb"
 		UserRegistrationHandler = require "../web/app/src/Features/User/UserRegistrationHandler"
 		OneTimeTokenHandler = require "../web/app/src/Features/Security/OneTimeTokenHandler"
-		UserRegistrationHandler.registerNewUser {
-			email: email
-			password: require("crypto").randomBytes(32).toString("hex")
-		}, (error, user) ->
-			if error? and error?.message != "EmailAlreadyRegistered"
-				throw error
-			user.isAdmin = true
-			user.save (error) ->
-				throw error if error?
-				ONE_WEEK = 7 * 24 * 60 * 60 # seconds
-				OneTimeTokenHandler.getNewToken "password", { expiresIn: ONE_WEEK, email:user.email, user_id: user._id.toString() }, (err, token)->
-					return next(err) if err?
-					
-					console.log ""
-					console.log """
-						Successfully created #{email} as an admin user.
-						
-						Please visit the following URL to set a password for #{email} and log in:
-						
-							#{settings.siteUrl}/user/password/set?passwordResetToken=#{token}
-						
-					"""
-					done()
+		mongodb.waitForDb().then () ->
+			UserRegistrationHandler.registerNewUser {
+				email: email
+				password: require("crypto").randomBytes(32).toString("hex")
+			}, (error, user) ->
+				if error? and error?.message != "EmailAlreadyRegistered"
+					throw error
+				user.isAdmin = true
+				user.save (error) ->
+					throw error if error?
+					ONE_WEEK = 7 * 24 * 60 * 60 # seconds
+					OneTimeTokenHandler.getNewToken "password", { expiresIn: ONE_WEEK, email:user.email, user_id: user._id.toString() }, (err, token)->
+						return next(err) if err?
+
+						console.log ""
+						console.log """
+							Successfully created #{email} as an admin user.
+
+							Please visit the following URL to set a password for #{email} and log in:
+
+								#{settings.siteUrl}/user/password/set?passwordResetToken=#{token}
+
+						"""
+						done()
 
 	grunt.registerTask 'user:delete', "deletes a user and all their data, Usage: grunt user:delete --email joe@example.com", () ->
 		done = @async()
@@ -42,15 +44,17 @@ module.exports = (grunt) ->
 			console.error "Usage: grunt user:delete --email=joe@example.com"
 			process.exit(1)
 		settings = require "settings-sharelatex"
+		mongodb = require "../web/app/src/infrastructure/mongodb"
 		UserGetter = require "../web/app/src/Features/User/UserGetter"
 		UserDeleter = require "../web/app/src/Features/User/UserDeleter"
-		UserGetter.getUser email:email, (error, user) ->
-			if error?
-				throw error
-			if !user?
-				console.log("user #{email} not in database, potentially already deleted")
-				return done()
-			UserDeleter.deleteUser user._id, (err)->
-				if err?
-					throw err
-				done()
+		mongodb.waitForDb().then () ->
+			UserGetter.getUser email:email, (error, user) ->
+				if error?
+					throw error
+				if !user?
+					console.log("user #{email} not in database, potentially already deleted")
+					return done()
+				UserDeleter.deleteUser user._id, (err)->
+					if err?
+						throw err
+					done()


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Similar to https://github.com/overleaf/web-internal/pull/3255
Fixes https://github.com/overleaf/overleaf/issues/796

Accessing mongo through a Handler likely requires a `waitForDb` wrapper now -- and for the tasks this seems to be the case, see https://github.com/overleaf/overleaf/issues/796.

The native driver was merged last week, so this is not affecting our regular Server CE/Pro releases at this time -- no hotfix needed.

## Review

This is best reviewed with whitespace changes ignored: https://github.com/overleaf/overleaf/pull/797/files?diff=unified&w=1

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Similar to https://github.com/overleaf/web-internal/pull/3255
Fixes https://github.com/overleaf/overleaf/issues/796

