### PR TITLE
Fix email custom footer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
             # SHARELATEX_EMAIL_SMTP_PASS:
             # SHARELATEX_EMAIL_SMTP_TLS_REJECT_UNAUTH: true
             # SHARELATEX_EMAIL_SMTP_IGNORE_TLS: false
-            # SHARELATEX_CUSTOM_EMAIL_FOOTER: "<div>This system is run by department x </div>"
+            # SHARELATEX_CUSTOM_EMAIL_FOOTER: "This system is run by department x"
 
             ################
             ## Server Pro ##

--- a/settings.coffee
+++ b/settings.coffee
@@ -283,7 +283,7 @@ if process.env["SHARELATEX_EMAIL_FROM_ADDRESS"]?
 			ignoreTLS: parse(process.env["SHARELATEX_EMAIL_SMTP_IGNORE_TLS"])
 
 		textEncoding:  process.env["SHARELATEX_EMAIL_TEXT_ENCODING"]
-		templates:
+		template:
 			customFooter: process.env["SHARELATEX_CUSTOM_EMAIL_FOOTER"]
 
 	if process.env["SHARELATEX_EMAIL_SMTP_USER"]? or process.env["SHARELATEX_EMAIL_SMTP_PASS"]?


### PR DESCRIPTION
## Description

Fixes a setting that should be `template` instead of `template` for `settings.email.template.customFooter`:

https://github.com/overleaf/web/blob/52fe2a959eee9916436b9c9b7fa79ec6dcd606c7/app/src/Features/Email/EmailBuilder.js#L120-L122


Also removes the `<div>` from the default footer, which should be avoided in HTML emails: https://mailchimp.com/help/limitations-of-html-email/