### PR TITLE
Expose COMPILE_TIMEOUT env variable and update nginx timeouts

### DIFF
--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -11,8 +11,8 @@ server {
 		proxy_set_header Connection "upgrade";
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_read_timeout 3m;
-		proxy_send_timeout 3m;
+		proxy_read_timeout 4m;
+		proxy_send_timeout 4m;
 	}
 
 	location /socket.io {
@@ -23,8 +23,8 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_read_timeout 3m;
-		proxy_send_timeout 3m;
+		proxy_read_timeout 4m;
+		proxy_send_timeout 4m;
 	}
 
 	location /stylesheets {

--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -11,8 +11,8 @@ server {
 		proxy_set_header Connection "upgrade";
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_read_timeout 4m;
-		proxy_send_timeout 4m;
+		proxy_read_timeout 10m;
+		proxy_send_timeout 10m;
 	}
 
 	location /socket.io {
@@ -23,8 +23,8 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_read_timeout 4m;
-		proxy_send_timeout 4m;
+		proxy_read_timeout 10m;
+		proxy_send_timeout 10m;
 	}
 
 	location /stylesheets {

--- a/settings.coffee
+++ b/settings.coffee
@@ -213,7 +213,7 @@ settings =
 		collaborators: -1
 		dropbox: true
 		versioning: true
-		compileTimeout: parseInt(process.env["COMPILE_TIMEOUT"]) or 180
+		compileTimeout: parseInt(process.env["COMPILE_TIMEOUT"] or 180, 10)
 		compileGroup: "standard"
 		trackChanges: true
 		templates: true

--- a/settings.coffee
+++ b/settings.coffee
@@ -213,7 +213,7 @@ settings =
 		collaborators: -1
 		dropbox: true
 		versioning: true
-		compileTimeout: process.env["COMPILE_TIMEOUT"] or 180
+		compileTimeout: parseInt(process.env["COMPILE_TIMEOUT"]) or 180
 		compileGroup: "standard"
 		trackChanges: true
 		templates: true

--- a/settings.coffee
+++ b/settings.coffee
@@ -213,7 +213,7 @@ settings =
 		collaborators: -1
 		dropbox: true
 		versioning: true
-		compileTimeout: 180
+		compileTimeout: process.env["COMPILE_TIMEOUT"] or 180
 		compileGroup: "standard"
 		trackChanges: true
 		templates: true


### PR DESCRIPTION
## Description

- Exposes a `COMPILE_TIMEOUT` environment variable
- Updates nginx timeouts to ~4m~ 10m

Any user looking forward to update the timeouts should do the following:
- Update nginx timeouts by mounting a new config file in `/etc/nginx/sites-enabled/sharelatex.conf`
- Set `COMPILE_TIMEOUT` to that same value
- Run a script to update timeouts for existing users with `db.users.updateMany({}, {'$set': {'features.compileTimeout': <value>}})`

Users created subsequently will have their default timeout set to the environment variable `COMPILE_TIMEOUT`.
