### PR TITLE
Modified expose port declaration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             redis:
                 condition: service_started
         ports:
-            - 80:80
+            - "80:80"
         links:
             - mongo
             - redis
@@ -105,7 +105,7 @@ services:
         image: mongo:4.0
         container_name: mongo
         expose:
-            - 27017
+            - "27017"
         volumes:
             - ~/mongo_data:/data/db
         healthcheck:
@@ -119,7 +119,7 @@ services:
         image: redis:5
         container_name: redis
         expose:
-            - 6379
+            - "6379"
         volumes:
             - ~/redis_data:/data
 


### PR DESCRIPTION
## Description
Using the **overleaf** docker-compose file with `podman-compose` I encountered some errors because the values declared with the `expose` parameter are not surrounded with double-quotes. This should be done as per documentation: https://docs.docker.com/compose/compose-file/#expose.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
