### PR TITLE
[misc] fix contacts logging

### DIFF
--- a/init_scripts/10_delete_old_logs.sh
+++ b/init_scripts/10_delete_old_logs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Up to version 2.5.0 the logs of the contacts service were written into a
+#  file that was not picked up by logrotate.
+# The service is stable and we can safely discard any logs.
+rm -vf /var/log/sharelatex/contacts

--- a/runit/contacts-sharelatex/run
+++ b/runit/contacts-sharelatex/run
@@ -7,4 +7,4 @@ if [ "$DEBUG_NODE" == "true" ]; then
     NODE_PARAMS="--inspect=0.0.0.0:30360"
 fi
 
-exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/contacts/app.js >> /var/log/sharelatex/contacts 2>&1
+exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/contacts/app.js >> /var/log/sharelatex/contacts.log 2>&1


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

For https://digital-science.slack.com/archives/G6256GXGS/p1610444613010600?thread_ts=1610014416.061300&cid=G6256GXGS

The logs of the contacts service are not processed by logrotate. 
This PR is fixing the log path for the service and deletes the old logs during the next init (in case the logs are persisted).


A hothix proposal is at https://github.com/overleaf/overleaf/compare/jpa-hotfix-logrotate


