### PR TITLE
Update logrotate config file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ ADD ${baseDir}/nginx/sharelatex.conf /etc/nginx/sites-enabled/sharelatex.conf
 # Configure log rotation
 # ----------------------
 ADD ${baseDir}/logrotate/sharelatex /etc/logrotate.d/sharelatex
+RUN chmod 644 /etc/logrotate.d/sharelatex
 
 
 # Copy Phusion Image startup scripts to its location


### PR DESCRIPTION
## Description

`logrotate` is failing to run `/etc/logrotate.d/sharelatex` due to existing `write` permisions.

```
error: Ignoring /etc/logrotate.d/sharelatex because of bad file mode - must be 0644 or 0444.
```

Updating the config permissions to be the same as other config fixes the issue.

Before:
 
```
$ ls -l /etc/logrotate.d
-rw-r--r-- 1 root root 120 Nov  2  2017 alternatives
-rw-r--r-- 1 root root 173 Apr 20  2018 apt
-rw-r--r-- 1 root root 112 Nov  2  2017 dpkg
-rw-r--r-- 1 root root 329 Apr  6  2018 nginx
-rw-rw-r-- 1 root root 123 Jan 12 13:06 sharelatex
-rw-r--r-- 1 root root 609 Aug 16  2018 syslog-ng
```
After:
```
$ ls -l /etc/logrotate.d
-rw-r--r-- 1 root root 120 Nov  2  2017 alternatives
-rw-r--r-- 1 root root 173 Apr 20  2018 apt
-rw-r--r-- 1 root root 112 Nov  2  2017 dpkg
-rw-r--r-- 1 root root 329 Apr  6  2018 nginx
-rw-r--r-- 1 root root 123 Jan 12 13:06 sharelatex
-rw-r--r-- 1 root root 609 Aug 16  2018 syslog-ng
```

