### PR TITLE
[hotfix] produce version 2.5.1 with fixes for log rotation

### DIFF
--- a/hotfix/2.5.1/Dockerfile
+++ b/hotfix/2.5.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM sharelatex/sharelatex:2.5.0
+
+# Patch #826: Fixes log path for contacts service to be picked up by logrotate
+COPY contacts-run.patch /etc/service/contacts-sharelatex
+RUN cd /etc/service/contacts-sharelatex && patch < contacts-run.patch
+
+# Patch #826: delete old logs for the contacts service
+COPY delete-old-logs.patch /etc/my_init.d
+RUN cd /etc/my_init.d && patch < delete-old-logs.patch \
+&&  chmod +x /etc/my_init.d/10_delete_old_logs.sh
+
+# Patch #827: fix logrotate file permissions
+RUN chmod 644 /etc/logrotate.d/sharelatex

--- a/hotfix/2.5.1/contacts-run.patch
+++ b/hotfix/2.5.1/contacts-run.patch
@@ -1,0 +1,8 @@
+--- a/run
++++ b/run
+@@ -7,4 +7,4 @@ if [ "$DEBUG_NODE" == "true" ]; then
+     NODE_PARAMS="--inspect=0.0.0.0:30360"
+ fi
+
+-exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/contacts/app.js >> /var/log/sharelatex/contacts 2>&1
++exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/contacts/app.js >> /var/log/sharelatex/contacts.log 2>&1

--- a/hotfix/2.5.1/delete-old-logs.patch
+++ b/hotfix/2.5.1/delete-old-logs.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ b/10_delete_old_logs.sh
+@@ -0,0 +1,7 @@
++#!/bin/sh
++set -e
++
++# Up to version 2.5.0 the logs of the contacts service were written into a
++#  file that was not picked up by logrotate.
++# The service is stable and we can safely discard any logs.
++rm -vf /var/log/sharelatex/contacts


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Package #826 and #827 into a hotfix release.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/issues/issues/3921
#826 
#827

## Manual testing performed

<details>

```
# build
$ docker build -t sharelatex/sharelatex:2.5.1-local .
Sending build context to Docker daemon  4.608kB
Step 1/6 : FROM sharelatex/sharelatex:2.5.0
 ---> 6e6f3526af69
Step 2/6 : COPY contacts-run.patch /etc/service/contacts-sharelatex
 ---> Using cache
 ---> 278ede9e71b5
Step 3/6 : RUN cd /etc/service/contacts-sharelatex && patch < contacts-run.patch
 ---> Using cache
 ---> 1928163d861c
Step 4/6 : COPY delete-old-logs.patch /etc/my_init.d
 ---> Using cache
 ---> b339aa9935bb
Step 5/6 : RUN cd /etc/my_init.d && patch < delete-old-logs.patch &&  chmod +x /etc/my_init.d/10_delete_old_logs.sh
 ---> Using cache
 ---> a4870b3f1a81
Step 6/6 : RUN chmod 644 /etc/logrotate.d/sharelatex
 ---> Running in e4068be923c8
Removing intermediate container e4068be923c8
 ---> 5d6493ce30fe
Successfully built 5d6493ce30fe
Successfully tagged sharelatex/sharelatex:2.5.1-local
```


```
# new log path is set
$ docker run --rm --entrypoint cat sharelatex/sharelatex:2.5.1-local /etc/service/contacts-sharelatex/run
#!/bin/bash
export SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee

NODE_PARAMS=""
if [ "$DEBUG_NODE" == "true" ]; then
    echo "running debug - contacts"
    NODE_PARAMS="--inspect=0.0.0.0:30360"
fi

exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /var/www/sharelatex/contacts/app.js >> /var/log/sharelatex/contacts.log 2>&1
```

```
# contacts entrypoint is executable
$ docker run --rm --entrypoint ls sharelatex/sharelatex:2.5.1-local -l /etc/service/contacts-sharelatex/run
-rwxrwxr-x 1 root root 336 Jan 12 10:32 /etc/service/contacts-sharelatex/run
```

```
# deletion script is in place
$ docker run --rm --entrypoint cat sharelatex/sharelatex:2.5.1-local /etc/my_init.d/10_delete_old_logs.sh
#!/bin/sh
set -e

# Up to version 2.5.0 the logs of the contacts service were written into a
#  file that was not picked up by logrotate.
# The service is stable and we can safely discard any logs.
rm -vf /var/log/sharelatex/contacts
```

```
# deletion script is executable
$ docker run --rm --entrypoint ls sharelatex/sharelatex:2.5.1-local -l /etc/my_init.d/10_delete_old_logs.sh
-rwxr-xr-x 1 root root 234 Jan 12 10:32 /etc/my_init.d/10_delete_old_logs.sh
```

_Put the new image tag in the docker-compose config_

```
# delete script runs
$ docker-compose up
...
sharelatex    | *** Running /etc/my_init.d/10_delete_old_logs.sh...
```

```
# logrotate config
$ docker exec -it sharelatex bash
in-container$ logrotate --debug /etc/logrotate.conf 2>&1 | grep sharelatex/
rotating pattern: /var/log/sharelatex/*.log  after 1 days (5 rotations)
considering log /var/log/sharelatex/chat.log
considering log /var/log/sharelatex/clsi.log
considering log /var/log/sharelatex/contacts.log
considering log /var/log/sharelatex/docstore.log
considering log /var/log/sharelatex/document-updater.log
considering log /var/log/sharelatex/filestore.log
considering log /var/log/sharelatex/notifications.log
considering log /var/log/sharelatex/real-time.log
considering log /var/log/sharelatex/spelling.log
considering log /var/log/sharelatex/track-changes.log
considering log /var/log/sharelatex/web.log
 
```