### PR TITLE
#801: Fix gruntfile services include path

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -12,7 +12,7 @@ settings = require("settings-sharelatex")
 _ = require("underscore")
 
 
-SERVICES = require("./config/services")
+SERVICES = require("./services")
 
 module.exports = (grunt) ->
 	grunt.loadNpmTasks 'grunt-bunyan'


### PR DESCRIPTION
## Description
To allow developers to install the overleaf services via grunt install.


## Related issues / Pull Requests
Fixes #801 


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
