### PR TITLE
Expose new smtp vars: 'name', and 'logger'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
             # SHARELATEX_EMAIL_SMTP_PASS:
             # SHARELATEX_EMAIL_SMTP_TLS_REJECT_UNAUTH: true
             # SHARELATEX_EMAIL_SMTP_IGNORE_TLS: false
+            # SHARELATEX_EMAIL_SMTP_NAME: '127.0.0.1'
+            # SHARELATEX_EMAIL_SMTP_LOGGER: true
             # SHARELATEX_CUSTOM_EMAIL_FOOTER: "This system is run by department x"
 
             ################

--- a/settings.coffee
+++ b/settings.coffee
@@ -285,6 +285,8 @@ if process.env["SHARELATEX_EMAIL_FROM_ADDRESS"]?
 			port: process.env["SHARELATEX_EMAIL_SMTP_PORT"],
 			secure: parse(process.env["SHARELATEX_EMAIL_SMTP_SECURE"])
 			ignoreTLS: parse(process.env["SHARELATEX_EMAIL_SMTP_IGNORE_TLS"])
+			name: process.env["SHARELATEX_EMAIL_SMTP_NAME"]
+			logger: process.env["SHARELATEX_EMAIL_SMTP_LOGGER"] == 'true'
 
 		textEncoding:  process.env["SHARELATEX_EMAIL_TEXT_ENCODING"]
 		template:


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Exposes two new settings via environment variables:

- `SHARELATEX_EMAIL_SMTP_NAME`
- `SHARELATEX_EMAIL_SMTP_LOGGER`

These are required for CE/SP users with their own email infrastructure.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

- Part of https://github.com/overleaf/issues/issues/3685
- Sibling of https://github.com/overleaf/web-internal/pull/3786


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
