### PR TITLE
Add the new `outputDir` setting for CLSI

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -148,6 +148,8 @@ settings =
 		compilesDir:  Path.join(DATA_DIR, "compiles")
 		# Where to cache downloaded URLs for the CLSI
 		clsiCacheDir: Path.join(DATA_DIR, "cache")
+		# Where to write the output files to disk after running LaTeX
+		outputDir:  Path.join(DATA_DIR, "output")
 
 	# Server Config
 	# -------------
@@ -569,4 +571,3 @@ https = require('https')
 https.globalAgent.maxSockets = 300
 
 module.exports = settings
-


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Add the new `outputDir` setting for CLSI. Without this setting, the application tries to create the `output` directory _relative to it's own source code_, which fails in CE/SP, preventing compiles from working fully.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

- Discovered while working on https://github.com/overleaf/issues/issues/3029
- Probably related to a change introduced in https://github.com/overleaf/clsi/pull/204


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
