### PR TITLE
[migrations] open source newly added indexes

### DIFF
--- a/migrations/12_add_deletedFiles_indexes.js
+++ b/migrations/12_add_deletedFiles_indexes.js
@@ -1,0 +1,25 @@
+// Internal ticket: https://github.com/overleaf/issues/issues/4094
+
+const Settings = require('settings-sharelatex')
+const mongojs = require('mongojs')
+const db = mongojs(Settings.mongo.url, ['deletedFiles'])
+
+const INDEX_FILTER = { 'projectId_1': 1 }
+const INDEX_OPTIONS = {
+  key: {
+    projectId: 1
+  },
+  background: 1
+}
+
+exports.migrate = (client, done) => {
+  db.deletedFiles.ensureIndex(
+    INDEX_FILTER,
+    INDEX_OPTIONS,
+    done
+  )
+}
+
+exports.rollback = (client, done) => {
+  db.deletedFiles.dropIndex(INDEX_FILTER, done)
+}

--- a/migrations/13_add_deleted_docs_index.js
+++ b/migrations/13_add_deleted_docs_index.js
@@ -1,0 +1,27 @@
+// Internal ticket: https://github.com/overleaf/issues/issues/4211
+
+const Settings = require('settings-sharelatex')
+const mongojs = require('mongojs')
+const db = mongojs(Settings.mongo.url, ['docs'])
+
+const INDEX_FILTER = { 'project_id_deleted_deletedAt_1': 1 }
+const INDEX_OPTIONS = {
+  key: {
+    project_id: 1,
+    deleted: 1,
+    deletedAt: -1
+  },
+  background: 1
+}
+
+exports.migrate = (client, done) => {
+  db.docs.ensureIndex(
+    INDEX_FILTER,
+    INDEX_OPTIONS,
+    done
+  )
+}
+
+exports.rollback = (client, done) => {
+  db.docs.dropIndex(INDEX_FILTER, done)
+}


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
For https://digital-science.slack.com/archives/C01P80H0VU3/p1617888182011400?thread_ts=1617879084.006100&cid=C01P80H0VU3
As discussed in slack I am open sourcing some index that were added during the deleted files/docs migration.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
For https://digital-science.slack.com/archives/C01P80H0VU3/p1617888182011400?thread_ts=1617879084.006100&cid=C01P80H0VU3
