### PR TITLE
[migrations] fix index creation

### DIFF
--- a/migrations/12_add_deletedFiles_indexes.js
+++ b/migrations/12_add_deletedFiles_indexes.js
@@ -4,22 +4,21 @@ const Settings = require('settings-sharelatex')
 const mongojs = require('mongojs')
 const db = mongojs(Settings.mongo.url, ['deletedFiles'])
 
-const INDEX_FILTER = { 'projectId_1': 1 }
+const INDEX_NAME = 'projectId_1'
+const INDEX_KEYS = { projectId: 1 }
 const INDEX_OPTIONS = {
-  key: {
-    projectId: 1
-  },
+  name: INDEX_NAME,
   background: 1
 }
 
 exports.migrate = (client, done) => {
   db.deletedFiles.ensureIndex(
-    INDEX_FILTER,
+    INDEX_KEYS,
     INDEX_OPTIONS,
     done
   )
 }
 
 exports.rollback = (client, done) => {
-  db.deletedFiles.dropIndex(INDEX_FILTER, done)
+  db.deletedFiles.dropIndex(INDEX_NAME, done)
 }

--- a/migrations/13_add_deleted_docs_index.js
+++ b/migrations/13_add_deleted_docs_index.js
@@ -4,24 +4,25 @@ const Settings = require('settings-sharelatex')
 const mongojs = require('mongojs')
 const db = mongojs(Settings.mongo.url, ['docs'])
 
-const INDEX_FILTER = { 'project_id_deleted_deletedAt_1': 1 }
+const INDEX_NAME = 'project_id_deleted_deletedAt_1'
+const INDEX_KEYS = {
+  project_id: 1,
+  deleted: 1,
+  deletedAt: -1
+}
 const INDEX_OPTIONS = {
-  key: {
-    project_id: 1,
-    deleted: 1,
-    deletedAt: -1
-  },
+  name: INDEX_NAME,
   background: 1
 }
 
 exports.migrate = (client, done) => {
   db.docs.ensureIndex(
-    INDEX_FILTER,
+    INDEX_KEYS,
     INDEX_OPTIONS,
     done
   )
 }
 
 exports.rollback = (client, done) => {
-  db.docs.dropIndex(INDEX_FILTER, done)
+  db.docs.dropIndex(INDEX_NAME, done)
 }


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Followup for https://github.com/overleaf/overleaf/pull/870

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/overleaf/pull/870

#### Manual testing performed

Hack configs to run migrations in a local mongodb container.

```
> db.docs.getIndexes()
[
        {
                "v" : 2,
                "key" : {
                        "_id" : 1
                },
                "name" : "_id_"
        },
        {
                "v" : 2,
                "key" : {
                        "project_id" : 1,
                        "deleted" : 1,
                        "deletedAt" : -1
                },
                "name" : "project_id_deleted_deletedAt_1",
                "background" : 1
        }
]
```
``` 
> db.deletedFiles.getIndexes()
[
        {
                "v" : 2,
                "key" : {
                        "_id" : 1
                },
                "name" : "_id_"
        },
        {
                "v" : 2,
                "key" : {
                        "projectId" : 1
                },
                "name" : "projectId_1",
                "background" : 1
        }
]
``` 