### PR TITLE
fix redis config

### DIFF
--- a/settings.coffee
+++ b/settings.coffee
@@ -55,8 +55,6 @@ settings =
 			host: process.env["SHARELATEX_REDIS_HOST"] or "dockerhost"
 			port: process.env["SHARELATEX_REDIS_PORT"] or "6379"
 			password: process.env["SHARELATEX_REDIS_PASS"] or undefined
-			db: process.env["SHARELATEX_REDIS_DB"] or undefined
-			prefix: process.env["SHARELATEX_REDIS_PREFIX"] or undefined
 			key_schema:
 				# document-updater
 				blockingKey: ({doc_id}) -> "Blocking:#{doc_id}"

--- a/settings.coffee
+++ b/settings.coffee
@@ -54,7 +54,9 @@ settings =
 		web: redisConfig =
 			host: process.env["SHARELATEX_REDIS_HOST"] or "dockerhost"
 			port: process.env["SHARELATEX_REDIS_PORT"] or "6379"
-			password: process.env["SHARELATEX_REDIS_PASS"] or ""
+			password: process.env["SHARELATEX_REDIS_PASS"] or undefined
+			db: process.env["SHARELATEX_REDIS_DB"] or undefined
+			prefix: process.env["SHARELATEX_REDIS_PREFIX"] or undefined
 			key_schema:
 				# document-updater
 				blockingKey: ({doc_id}) -> "Blocking:#{doc_id}"


### PR DESCRIPTION
## Description
This fix when using redis on host machine without password auth
As documented in https://www.npmjs.com/package/redis , the default value for password in redis config is null not ""


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
