### PR TITLE
fix nginx conf

### DIFF
--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -10,8 +10,6 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
 		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header REMOTE-HOST $remote_addr;
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_read_timeout 10m;
@@ -24,8 +22,6 @@ server {
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
 		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header REMOTE-HOST $remote_addr;
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -9,6 +9,10 @@ server {
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header REMOTE-HOST $remote_addr;
+		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_read_timeout 10m;
@@ -20,6 +24,9 @@ server {
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header REMOTE-HOST $remote_addr;
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/sharelatex.conf
+++ b/nginx/sharelatex.conf
@@ -12,7 +12,6 @@ server {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header REMOTE-HOST $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_read_timeout 10m;


### PR DESCRIPTION
## Description
using nginx conf of last version, IN `app/src/infrastructure/Translations.js` the `setLangBasedOnDomainMiddleware` would get the `req.headers.host` as `127.0.0.1:3000` not the domain. and this leads to the failing multi-languages support.

To Reproduce, make a clean install with multi-languages settings, add the following log commant to the file `app/src/infrastructure/Translations.js`, and restart the container:
```js
const logger = require('logger-sharelatex')
function setLangBasedOnDomainMiddleware(req, res, next) {
  // Determine language from subdomain
  const lang = availableHosts.get(req.headers.host)
  if (lang) {
    req.i18n.changeLanguage(lang)
  }
// add this line !!!!!!!
  logger.log(`host: ${req.headers.host}, lang: ${lang}`)

  // expose the language code to pug
  res.locals.currentLngCode = req.language

  // If the set language is different from the language detection (based on
  // the Accept-Language header), then set flag which will show a banner
  // offering to switch to the appropriate library
  const detectedLanguageCode = headerLangDetector.detect(req, res)
  if (req.language !== detectedLanguageCode) {
    res.locals.suggestedLanguageSubdomainConfig = subdomainConfigs.get(
      detectedLanguageCode
    )
  }

  // Decorate req.i18n with translate function alias for backwards
  // compatibility usage in requests
  req.i18n.translate = req.i18n.t
  next()
}
```
and in the log of web, we can see this:
```
{"name":"web","hostname":"3d37c48f1b4a","pid":166,"level":30,"msg":"host: 127.0.0.1:3000, lang: undefined","time":"2021-06-02T13:33:20.494Z","v":0}
```

with this fix, the log would be:
```
{"name":"web","hostname":"0f11a0bb43e8","pid":157,"level":30,"msg":"host: www.domain.com, lang: en","time":"2021-06-02T13:39:10.981Z","v":0}
```


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
