### PR TITLE
Renamed SAML setting `privateCert` -> `privateKey`

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -680,7 +680,7 @@ if (process.env.SHARELATEX_SAML_ENTRYPOINT) {
   // https://github.com/node-saml/passport-saml/commit/f6b1c885c0717f1083c664345556b535f217c102
   if (process.env.SHARELATEX_SAML_CERT) {
     settings.saml.server.cert = process.env.SHARELATEX_SAML_CERT
-    settings.saml.server.privateCert = process.env.SHARELATEX_SAML_PRIVATE_CERT
+    settings.saml.server.privateKey = process.env.SHARELATEX_SAML_PRIVATE_CERT
   }
 }
 


### PR DESCRIPTION


## Description

Renamed SAML setting `privateCert` -> `privateKey`,  as required by `passport-saml` update to 3.x.
<!-- Goal of the pull request -->


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
