### PR TITLE
[misc] bin/grunt: keep up with changes to create-admin script

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -9,7 +9,7 @@ cd /var/www/sharelatex/web/modules/server-ce-scripts/scripts
 
 case "$TASK" in
   user:create-admin)
-    node create-admin "$@"
+    node create-user --admin "$@"
     ;;
 
   user:delete)


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Sibling of https://github.com/overleaf/web-internal/pull/4324

The `create-admin` script has been superseded by a `create-user` script with `--admin` flag.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Sibling of https://github.com/overleaf/web-internal/pull/4324
