### PR TITLE
Remove `linked_url` from `ENABLED_LINKED_FILE_TYPES` env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             SHARELATEX_REDIS_HOST: redis
             REDIS_HOST: redis
 
-            ENABLED_LINKED_FILE_TYPES: 'url,project_file'
+            ENABLED_LINKED_FILE_TYPES: 'project_file,project_output_file'
 
             # Enables Thumbnail generation using ImageMagick
             ENABLE_CONVERSIONS: 'true'


### PR DESCRIPTION
## Description

`linked-url` is not available in CE/SP. Also added `project_output_file` as default.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
