### PR TITLE
services/filestore: should be aware of LISTEN_ADDRESS

### DIFF
--- a/services/filestore/app.js
+++ b/services/filestore/app.js
@@ -136,7 +136,7 @@ app.get('/health_check', healthCheckController.check)
 app.use(RequestLogger.errorHandler)
 
 const port = settings.internal.filestore.port || 3009
-const host = '0.0.0.0'
+const host = settings.internal.filestore.host || '0.0.0.0'
 
 if (!module.parent) {
   // Called directly


### PR DESCRIPTION

## Description
filestore will listen on '0.0.0.0' unconditionally, because it hardcodes '0.0.0.0' in its [app.js](https://github.com/overleaf/overleaf/blob/844f92b8c127acf16010ae98e42f3c6c072b7b0a/services/filestore/app.js#L139).

It could make filestore unfunctional. For example, if I set `LISTEN_ADDRESS` and `FILESTORE_HOST` to `::1` and run filestore on an ipv6-compatible host, the web interface will not be able to connect to filestore.

This PR is going to make it aware of the `LISTEN_ADDRESS` environment variable.

## Related issues / Pull Requests
No related issues.


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
