### PR TITLE
remove initial condition for passwordStrengthOptions

### DIFF
--- a/server-ce/settings.js
+++ b/server-ce/settings.js
@@ -424,18 +424,12 @@ if (process.env.SHARELATEX_LANG_DOMAIN_MAPPING != null) {
 // -----------
 // These restrict the passwords users can use when registering
 // opts are from http://antelle.github.io/passfield
-if (
-  process.env.SHARELATEX_PASSWORD_VALIDATION_PATTERN ||
-  process.env.SHARELATEX_PASSWORD_VALIDATION_MIN_LENGTH ||
-  process.env.SHARELATEX_PASSWORD_VALIDATION_MAX_LENGTH
-) {
-  settings.passwordStrengthOptions = {
-    pattern: process.env.SHARELATEX_PASSWORD_VALIDATION_PATTERN || 'aA$3',
-    length: {
-      min: process.env.SHARELATEX_PASSWORD_VALIDATION_MIN_LENGTH || 8,
-      max: process.env.SHARELATEX_PASSWORD_VALIDATION_MAX_LENGTH || 150,
-    },
-  }
+settings.passwordStrengthOptions = {
+  pattern: process.env.SHARELATEX_PASSWORD_VALIDATION_PATTERN || 'aA$3',
+  length: {
+    min: process.env.SHARELATEX_PASSWORD_VALIDATION_MIN_LENGTH || 8,
+    max: process.env.SHARELATEX_PASSWORD_VALIDATION_MAX_LENGTH || 150,
+  },
 }
 
 // ######################


### PR DESCRIPTION
## Description

Fix 500 internal server error for 
- Reset password
- New user set password

`passwordStrengthOptions` is always used in
- `services/web/app/views/user/setPassword.pug`.
- `services/web/modules/user-activate/app/views/user/activate.pug` 
relevant to https://github.com/overleaf/overleaf/issues/961

## Related issues / Pull Requests

Related to https://github.com/overleaf/overleaf/issues/961

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
