### PR TITLE
correct PHONY target in Makefile

### DIFF
--- a/server-ce/Makefile
+++ b/server-ce/Makefile
@@ -17,4 +17,4 @@ build-community:
 	docker build --build-arg SHARELATEX_BASE_TAG --build-arg MONOREPO_REVISION -f Dockerfile -t $(SHARELATEX_TAG) $(MONOREPO_ROOT)
 
 
-PHONY: build-base build-community
+.PHONY: build-base build-community


### PR DESCRIPTION
## Description
Fixed PHONY target in Makefile.
From the official document [ref](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html), the phony target should be `.PHONY` instead of `PHONY`


## Related issues / Pull Requests


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
