### PR TITLE
fix zh-cn translation

### DIFF
--- a/services/web/locales/zh-CN.json
+++ b/services/web/locales/zh-CN.json
@@ -309,7 +309,7 @@
   "user_already_added": "用户已添加",
   "bonus_twitter_share_text": "我使用的是免费的在线协作 LaTeX 编辑器 __appName__，它非常棒，而且很容易使用！",
   "bonus_email_share_header": "你可能喜欢的在线LaTeX编辑器",
-  "bonus_email_share_body": "嘿，我最近一直在使用在线乳胶编辑器__appName__，我想你可能会想看看。",
+  "bonus_email_share_body": "嘿，我最近一直在使用在线LaTeX编辑器__appName__，我想你可能会想看看。",
   "bonus_share_link_text": "在线LaTeX编辑器 __appName__",
   "bonus_facebook_name": "__appName__ - 在线LaTeX编辑器",
   "bonus_facebook_caption": "免费无限的项目和编译",


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Fix zh-CN translation, which translated "LaTeX" to “乳胶” in mistake.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
