### PR TITLE
Fix user settings template

### DIFF
--- a/services/web/app/views/user/settings.pug
+++ b/services/web/app/views/user/settings.pug
@@ -98,7 +98,7 @@ block content
 									h3 #{translate("change_password")}
 									if externalAuthenticationSystemUsed() && !settings.overleaf
 										p
-											Password settings are managed externally
+											| Password settings are managed externally
 									else if !hasPassword
 										p
 											| #[a(href="/user/password/reset", target='_blank') #{translate("no_existing_password")}]


### PR DESCRIPTION
## Description
This pull request fixes the user settings template when an external authentication system is used. Currently, the displayed text is “settings are managed externally” because “Password” is interpreted as a part of the template.

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
