### PR TITLE
Fix `Deleted Projects` inconsistency

### DIFF
--- a/services/web/app/views/project/list/side-bar.pug
+++ b/services/web/app/views/project/list/side-bar.pug
@@ -59,7 +59,7 @@
 		li(ng-class="{active: (filter == 'shared')}", ng-click="filterProjects('shared')")
 			a(href) #{translate("shared_with_you")}
 		li(ng-class="{active: (filter == 'archived')}", ng-click="filterProjects('archived')")
-			a(href) #{settings.overleaf ? translate("archived_projects") : translate("deleted_projects")}
+			a(href) #{translate("archived_projects")}
 		li(ng-class="{active: (filter == 'trashed')}", ng-click="filterProjects('trashed')")
 			a(href) #{translate("trashed_projects")}
 		li.separator


### PR DESCRIPTION
## Description

As `Trashed Projects` and `Deleted Projects` (filtered with `archived`) co-exists in community version, this might misled the users.

Remove the `settings.overleaf` check, so every instances will show `Archived Projects` instead of wrong `Deleted Projects`.


## Related issues / Pull Requests

Fixes #995 


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
