### PR TITLE
Ignore stderr output when running commands

### DIFF
--- a/services/clsi/app/js/LocalCommandRunner.js
+++ b/services/clsi/app/js/LocalCommandRunner.js
@@ -50,7 +50,7 @@ module.exports = CommandRunner = {
     }
 
     // run command as detached process so it has its own process group (which can be killed if needed)
-    const proc = spawn(command[0], command.slice(1), { cwd: directory, env })
+    const proc = spawn(command[0], command.slice(1), { cwd: directory, env, stdio: ['pipe', 'pipe', 'ignore'] })
 
     let stdout = ''
     proc.stdout.setEncoding('utf8').on('data', data => (stdout += data))


### PR DESCRIPTION
## Description
Ignore stderr output when running commands. stderr output gets never consumed and the child process blocks if the stderr buffer gets full 


## Related issues / Pull Requests
Fixes #1006


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
