### PR TITLE
Update TexLive year in Dockerfile-base

### DIFF
--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -42,7 +42,7 @@ RUN chmod +x /usr/bin/envsubst
 #     -f Dockerfile-base -t sharelatex/sharelatex-base .
 ARG TEXLIVE_MIRROR=http://mirror.ctan.org/systems/texlive/tlnet
 
-ENV PATH "${PATH}:/usr/local/texlive/2021/bin/x86_64-linux"
+ENV PATH "${PATH}:/usr/local/texlive/2022/bin/x86_64-linux"
 
 RUN mkdir /install-tl-unx \
 &&  curl -sSL \


### PR DESCRIPTION
## Description
Currently, when trying to build the Dockerfile (`make build-base`), we obtain the following error:
```
/bin/sh: 1: tlmgr: not found
```

This is because the texlive path has been updated and is no longer correct in the Dockerfile.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
