### PR TITLE
Update Dockerfiles for arm64 support

### DIFF
--- a/server-ce/Dockerfile
+++ b/server-ce/Dockerfile
@@ -5,6 +5,8 @@
 ARG SHARELATEX_BASE_TAG=sharelatex/sharelatex-base:latest
 FROM $SHARELATEX_BASE_TAG
 
+ARG TARGETARCH
+
 WORKDIR /overleaf
 
 # Add required source files
@@ -61,6 +63,13 @@ COPY server-ce/settings.js /etc/sharelatex/settings.js
 # -----------------------
 ADD server-ce/bin/grunt /usr/local/bin/grunt
 RUN chmod +x /usr/local/bin/grunt
+
+# Fix error with envsubst on arm64
+ # -----------------------
+ RUN if [ "$TARGETARCH" != "amd64" ]; then \
+  apt-get update && \
+  apt-get install -y gettext-base; \
+  fi
 
 # Set Environment Variables
 # --------------------------------

--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -43,6 +43,7 @@ RUN chmod +x /usr/bin/envsubst
 ARG TEXLIVE_MIRROR=http://mirror.ctan.org/systems/texlive/tlnet
 
 ENV PATH "${PATH}:/usr/local/texlive/2022/bin/x86_64-linux"
+ENV PATH "${PATH}:/usr/local/texlive/2022/bin/aarch64-linux"
 
 RUN mkdir /install-tl-unx \
 &&  curl -sSL \


### PR DESCRIPTION
## Description
This commit adds the aarch64 version of texlive to PATH,
which allows the base image to build.

A fix for envsubst on non-x64 architectures is also added.

The PR can be seen running below:
![image](https://user-images.githubusercontent.com/20731972/168407499-715020fa-d24d-4a45-ac71-46ec1fcb3963.png)

## Related issues / Pull Requests
Fixes: https://github.com/overleaf/overleaf/issues/957, https://github.com/overleaf/overleaf/issues/881 and https://github.com/overleaf/overleaf/issues/510
Related PR: https://github.com/overleaf/overleaf/pull/991, https://github.com/overleaf/overleaf/pull/969


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
