### PR TITLE
fix(sec): upgrade org.apache.commons:commons-compress to 1.21

### DIFF
--- a/services/git-bridge/pom.xml
+++ b/services/git-bridge/pom.xml
@@ -212,7 +212,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
         <!-- prometheus metrics -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-compress 1.20
- [CVE-2021-35517](https://www.oscs1024.com/hd/CVE-2021-35517)


### What did I do？
Upgrade org.apache.commons:commons-compress from 1.20 to 1.21 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>