### PR TITLE
Modify Latexmk option

### DIFF
--- a/services/clsi/app/js/LatexRunner.js
+++ b/services/clsi/app/js/LatexRunner.js
@@ -155,7 +155,7 @@ function _buildLatexCommand(mainFile, opts = {}) {
     'latexmk',
     '-cd',
     '-jobname=output',
-    '-auxdir=$COMPILE_DIR',
+    '-auxdir=./',
     '-outdir=$COMPILE_DIR',
     '-synctex=1',
     '-interaction=batchmode'


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

Changes `-auxdir` option for Latexmk so that *bibtex* can find `.bib` file(s) even from parent directories.

Note that unit tests are not updated accordingly, and therefore some of them might fail at this point (which seems likely at least by looking at `LatexRunnerTests.js`). It might also be a good idea to add a new test case so that this issue/bug won't be introduced again by accident in the future.

## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

Fixes #1067

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
