### PR TITLE
chore: added missing version numbers to workspaces

### DIFF
--- a/libraries/ranges-tracker/package.json
+++ b/libraries/ranges-tracker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/ranges-tracker",
+  "version": "1.0.0",
   "description": "Shared logic for syncing comments and tracked changes with operational transforms",
   "main": "index.cjs",
   "files": [

--- a/services/clsi/package.json
+++ b/services/clsi/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/clsi",
+  "version" : "0.1.4",
   "description": "A Node.js implementation of the CLSI LaTeX web-API",
   "private": true,
   "main": "app.js",

--- a/services/contacts/package.json
+++ b/services/contacts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/contacts",
+  "version": "0.1.0",
   "description": "An API for tracking contacts of a user",
   "private": true,
   "type": "module",

--- a/services/docstore/package.json
+++ b/services/docstore/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/docstore",
+  "version": "0.1.2",
   "description": "A CRUD API for handling text documents in projects",
   "private": true,
   "main": "app.js",

--- a/services/document-updater/package.json
+++ b/services/document-updater/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/document-updater",
+  "version": "0.1.4",
   "description": "An API for applying incoming updates to documents in real-time",
   "private": true,
   "main": "app.js",

--- a/services/filestore/package.json
+++ b/services/filestore/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/filestore",
+  "version": "0.1.4",
   "description": "An API for CRUD operations on binary files stored in S3",
   "private": true,
   "main": "app.js",

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/notifications",
+  "version": "0.0.1",
   "description": "An API to handle user notifications",
   "private": true,
   "main": "app.js",

--- a/services/project-history/package.json
+++ b/services/project-history/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/project-history",
+  "version": "2.0.0",
   "description": "An API for saving and compressing individual document updates into a browseable history",
   "private": true,
   "main": "app.js",

--- a/services/real-time/package.json
+++ b/services/real-time/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/real-time",
+  "version": "0.1.4",
   "description": "The socket.io layer of Overleaf for real-time editor interactions",
   "private": true,
   "main": "app.js",

--- a/services/track-changes/package.json
+++ b/services/track-changes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/track-changes",
+  "version": "0.1.4",
   "description": "An API for saving and compressing individual document updates into a browsable history",
   "private": true,
   "main": "app.js",

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@overleaf/web",
+  "version": "0.1.4",
   "description": "The HTTP front end for Overleaf",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Description

Hello, I am a nixpkgs maintainer, which is a packet manager where software is built in a reproducible way and in isolation. We are interested in having overleaf packaged in nixpkgs. Because software is built in a sandbox, it is important to have precise lockfiles to build our packets. I worked on building overleaf with Nix, and I had more luck having a reproducible lockfile with Yarn than NPM. Yarn only detects workspaces if they have version numbers, that's why I suggest adding version numbers to all workspace. It is also a good practice I believe.

These version numbers are a propositions, in some cases I may not have chosen the most adequate ones. I have used the pre-moving-to-monorepo versions numbers when I have found them.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
