### PR TITLE
Make the number of max entities per project configurable

### DIFF
--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -275,7 +275,7 @@ module.exports = {
 
   robotsNoindex: process.env.ROBOTS_NOINDEX === 'true' || false,
 
-  maxEntitiesPerProject: 2000,
+  maxEntitiesPerProject: parseInt(process.env.MAX_ENTITIES_PER_PROJECT || '2000', 10),
 
   maxUploadSize: 50 * 1024 * 1024, // 50 MB
   multerOptions: {


### PR DESCRIPTION
## Description
Currently overleaf projects have a hard file count limit of 2000 files per project. With this pull request a new environment variable `MAX_ENTITIES_PER_PROJECT` is introduced which controls the max file count limit per project. If this pull request gets merged the `project_has_too_many_files` translation key has to be adopted accordingly.


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
