### PR TITLE
Update sharelatex.conf to fix IPv6 issues reported in #1146

### DIFF
--- a/server-ce/nginx/sharelatex.conf
+++ b/server-ce/nginx/sharelatex.conf
@@ -10,7 +10,7 @@ server {
 	}
 
 	location / {
-		proxy_pass http://127.0.0.1:3000;
+		proxy_pass http://localhost:3000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
@@ -22,7 +22,7 @@ server {
 	}
 
 	location /socket.io {
-		proxy_pass http://127.0.0.1:3026;
+		proxy_pass http://localhost:3026;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";
@@ -48,22 +48,22 @@ server {
 
   # handle output files for specific users
   location ~ ^/project/([0-9a-f]+)/user/([0-9a-f]+)/build/([0-9a-f-]+)/output/output\.([a-z]+)$ {
-		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
+		proxy_pass http://localhost:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
   }
   # handle output files for anonymous users
   location ~ ^/project/([0-9a-f]+)/build/([0-9a-f-]+)/output/output\.([a-z]+)$ {
-		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
+		proxy_pass http://localhost:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
   }
   # PDF range for specific users
   location ~ ^/project/([0-9a-f]+)/user/([0-9a-f]+)/content/([0-9a-f-]+/[0-9a-f]+)$ {
-		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
+		proxy_pass http://localhost:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
   }
   # PDF range for anonymous users
   location ~ ^/project/([0-9a-f]+)/content/([0-9a-f-]+/[0-9a-f]+)$ {
-		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
+		proxy_pass http://localhost:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
   }
 


### PR DESCRIPTION


## Description
This changes how the NGINX proxy server resolves to the underlying sharelatex service. The change is to use "localhost" instead of the IPv4 address 127.0.0.1. There is an inconsistency in the current configuration as the App.js for sharelatex binds to "localhost" not 127.0.0.1, so if localhost resolves to the IPv6 address ::1, then there's a misconfiguration between nginx and the node.js server.

To fix this, either we make a change in the app.js for sharelatex to always force IPv4 by providing a 127.0.0.1 , or we just use whatever localhost binds to in both. For me, I think it is more logical to bind to localhost consistently, allowing the use of IPv6 or IPv4, whatever is preferred by the underlying system for "localhost".


## Related issues / Pull Requests
Fixes #1146


## Contributor Agreement

- I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
