### PR TITLE
Add list-users script to list extant overleaf users

### DIFF
--- a/services/web/modules/server-ce-scripts/scripts/list-users.js
+++ b/services/web/modules/server-ce-scripts/scripts/list-users.js
@@ -1,0 +1,30 @@
+const { waitForDb } = require('../../../app/src/infrastructure/mongodb');
+const UserGetter = require('../../../app/src/Features/User/UserGetter');
+
+async function main() {
+  await waitForDb();
+
+  try {
+    const users = await UserGetter.promises.getUsers({}, { _id: 1, email: 1 });
+    if (users.length === 0) {
+      console.log("No users found.");
+    } else {
+      users.forEach(user => {
+        console.log(`UserID: ${user._id}, Email: ${user.email}`);
+      });
+    }
+  } catch (error) {
+    console.error("Error listing users:", error);
+    process.exit(1);
+  }
+}
+
+main()
+  .then(() => {
+    console.error('Done.');
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
We identified the need to administratively generate a list of extant Overleaf users and to satisfy this need, we developed a script to do so. We wrote this script by looking at the existing scripts, such as `create-user.js`, `delete-user.js`, etc. and inferring the available interfaces to the database.

The motivation for this script sprang from our efforts to debug an Overleaf Community instance, during which we lost track of a handful of test user accounts we created. We recognize that there may already be a way to enumerate or otherwise list existing Overleaf user accounts, but we were unable to find it.

## Contributor Agreement

- [ X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
