### PR TITLE
fix tls Email settings

### DIFF
--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -14,26 +14,21 @@ ENV REBUILT_AFTER="2024-14-02"
 
 # Install dependencies
 # --------------------
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update \
+&&  apt-get install -y \
       unattended-upgrades \
-      build-essential wget net-tools unzip time imagemagick optipng strace nginx git python3 \
-      python-is-python3 zlib1g-dev libpcre3-dev gettext-base libwww-perl ca-certificates curl gnupg \
-      qpdf aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn \
-      aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-1901 aspell-el aspell-eo \
-      aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos \
-      aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it \
-      aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr \
-      aspell-ns aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss \
-      aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
-RUN unattended-upgrade -v
+      build-essential wget net-tools unzip time imagemagick optipng strace nginx git python3 python-is-python3 zlib1g-dev libpcre3-dev gettext-base libwww-perl ca-certificates curl gnupg \
+      qpdf \
+      aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-1901 aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu \
+&&  unattended-upgrade -v \
 # install Node.js https://github.com/nodesource/distributions#nodejs
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update
-RUN apt-get install -y nodejs
-RUN rm -rf \
+&&  mkdir -p /etc/apt/keyrings \
+&&  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+&&  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+&&  apt-get update \
+&&  apt-get install -y nodejs \
+    \
+&&  rm -rf \
 # We are adding a custom nginx config in the main Dockerfile.
       /etc/nginx/nginx.conf \
       /etc/nginx/sites-enabled/default \
@@ -49,41 +44,43 @@ RUN rm -rf \
 #     -f Dockerfile-base -t sharelatex/sharelatex-base .
 ARG TEXLIVE_MIRROR=https://ctan.crest.fr/tex-archive/systems/texlive/tlnet
 
-RUN mkdir /install-tl-unx
-RUN wget https://tug.org/texlive/files/texlive.asc
-RUN gpg --import texlive.asc
-RUN rm texlive.asc
-RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz
-RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512
-RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc
-RUN gpg --verify install-tl-unx.tar.gz.sha512.asc
-RUN sha512sum -c install-tl-unx.tar.gz.sha512
-RUN tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz
-RUN rm install-tl-unx.tar.gz*
-RUN echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile
-RUN echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile
-RUN echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile
-RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
-RUN /install-tl-unx/install-tl \
+RUN mkdir /install-tl-unx \
+&&  wget --quiet https://tug.org/texlive/files/texlive.asc \
+&&  gpg --import texlive.asc \
+&&  rm texlive.asc \
+&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz \
+&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512 \
+&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc \
+&&  gpg --verify install-tl-unx.tar.gz.sha512.asc \
+&&  sha512sum -c install-tl-unx.tar.gz.sha512 \
+&&  tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz \
+&&  rm install-tl-unx.tar.gz* \
+&&  echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile \
+&&  echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile \
+&&  echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile \
+&&  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile \
+    \
+&&  /install-tl-unx/install-tl \
       -profile /install-tl-unx/texlive.profile \
-      -repository ${TEXLIVE_MIRROR}
-RUN $(find /usr/local/texlive -name tlmgr) path add
-RUN tlmgr install --repository ${TEXLIVE_MIRROR} \
+      -repository ${TEXLIVE_MIRROR} \
+    \
+&&  $(find /usr/local/texlive -name tlmgr) path add \
+&&  tlmgr install --repository ${TEXLIVE_MIRROR} \
       latexmk \
       texcount \
       synctex \
       etoolbox \
-      xetex
-RUN tlmgr path add
-RUN rm -rf /install-tl-unx
+      xetex \
+&&  tlmgr path add \
+&&  rm -rf /install-tl-unx
 
 
 # Set up overleaf user and home directory
 # -----------------------------------------
-RUN adduser --system --group --home /overleaf --no-create-home overleaf 
-RUN mkdir -p /var/lib/overleaf
-RUN chown www-data:www-data /var/lib/overleaf
-RUN mkdir -p /var/log/overleaf
-RUN chown www-data:www-data /var/log/overleaf
-RUN mkdir -p /var/lib/overleaf/data/template_files
-RUN chown www-data:www-data /var/lib/overleaf/data/template_files
+RUN adduser --system --group --home /overleaf --no-create-home overleaf && \
+	mkdir -p /var/lib/overleaf && \
+	chown www-data:www-data /var/lib/overleaf && \
+	mkdir -p /var/log/overleaf && \
+	chown www-data:www-data /var/log/overleaf && \
+	mkdir -p /var/lib/overleaf/data/template_files && \
+	chown www-data:www-data /var/lib/overleaf/data/template_files

--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -14,21 +14,26 @@ ENV REBUILT_AFTER="2024-14-02"
 
 # Install dependencies
 # --------------------
-RUN apt-get update \
-&&  apt-get install -y \
+RUN apt-get update
+RUN apt-get install -y \
       unattended-upgrades \
-      build-essential wget net-tools unzip time imagemagick optipng strace nginx git python3 python-is-python3 zlib1g-dev libpcre3-dev gettext-base libwww-perl ca-certificates curl gnupg \
-      qpdf \
-      aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-1901 aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu \
-&&  unattended-upgrade -v \
+      build-essential wget net-tools unzip time imagemagick optipng strace nginx git python3 \
+      python-is-python3 zlib1g-dev libpcre3-dev gettext-base libwww-perl ca-certificates curl gnupg \
+      qpdf aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn \
+      aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-1901 aspell-el aspell-eo \
+      aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos \
+      aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it \
+      aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr \
+      aspell-ns aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss \
+      aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
+RUN unattended-upgrade -v
 # install Node.js https://github.com/nodesource/distributions#nodejs
-&&  mkdir -p /etc/apt/keyrings \
-&&  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-&&  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
-&&  apt-get update \
-&&  apt-get install -y nodejs \
-    \
-&&  rm -rf \
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install -y nodejs
+RUN rm -rf \
 # We are adding a custom nginx config in the main Dockerfile.
       /etc/nginx/nginx.conf \
       /etc/nginx/sites-enabled/default \
@@ -44,43 +49,41 @@ RUN apt-get update \
 #     -f Dockerfile-base -t sharelatex/sharelatex-base .
 ARG TEXLIVE_MIRROR=https://mirror.ox.ac.uk/sites/ctan.org/systems/texlive/tlnet
 
-RUN mkdir /install-tl-unx \
-&&  wget --quiet https://tug.org/texlive/files/texlive.asc \
-&&  gpg --import texlive.asc \
-&&  rm texlive.asc \
-&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz \
-&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512 \
-&&  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc \
-&&  gpg --verify install-tl-unx.tar.gz.sha512.asc \
-&&  sha512sum -c install-tl-unx.tar.gz.sha512 \
-&&  tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz \
-&&  rm install-tl-unx.tar.gz* \
-&&  echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile \
-&&  echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile \
-&&  echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile \
-&&  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile \
-    \
-&&  /install-tl-unx/install-tl \
+RUN mkdir /install-tl-unx
+RUN wget --quiet https://tug.org/texlive/files/texlive.asc
+RUN gpg --import texlive.asc
+RUN  rm texlive.asc
+RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz
+RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512
+RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc
+RUN  gpg --verify install-tl-unx.tar.gz.sha512.asc
+RUN  sha512sum -c install-tl-unx.tar.gz.sha512
+RUN  tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz
+RUN  rm install-tl-unx.tar.gz*
+RUN  echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile
+RUN  echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile
+RUN  echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile
+RUN  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
+RUN  /install-tl-unx/install-tl \
       -profile /install-tl-unx/texlive.profile \
-      -repository ${TEXLIVE_MIRROR} \
-    \
-&&  $(find /usr/local/texlive -name tlmgr) path add \
-&&  tlmgr install --repository ${TEXLIVE_MIRROR} \
+      -repository ${TEXLIVE_MIRROR}
+RUN  $(find /usr/local/texlive -name tlmgr) path add
+RUN  tlmgr install --repository ${TEXLIVE_MIRROR} \
       latexmk \
       texcount \
       synctex \
       etoolbox \
-      xetex \
-&&  tlmgr path add \
-&&  rm -rf /install-tl-unx
+      xetex
+RUN  tlmgr path add
+RUN  rm -rf /install-tl-unx
 
 
 # Set up overleaf user and home directory
 # -----------------------------------------
-RUN adduser --system --group --home /overleaf --no-create-home overleaf && \
-	mkdir -p /var/lib/overleaf && \
-	chown www-data:www-data /var/lib/overleaf && \
-	mkdir -p /var/log/overleaf && \
-	chown www-data:www-data /var/log/overleaf && \
-	mkdir -p /var/lib/overleaf/data/template_files && \
-	chown www-data:www-data /var/lib/overleaf/data/template_files
+RUN adduser --system --group --home /overleaf --no-create-home overleaf 
+RUN mkdir -p /var/lib/overleaf
+RUN chown www-data:www-data /var/lib/overleaf
+RUN mkdir -p /var/log/overleaf
+RUN chown www-data:www-data /var/log/overleaf
+RUN mkdir -p /var/lib/overleaf/data/template_files
+RUN chown www-data:www-data /var/lib/overleaf/data/template_files

--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -47,35 +47,35 @@ RUN rm -rf \
 # # docker build \
 #     --build-arg TEXLIVE_MIRROR=https://ctan.crest.fr/tex-archive/systems/texlive/tlnet \
 #     -f Dockerfile-base -t sharelatex/sharelatex-base .
-ARG TEXLIVE_MIRROR=https://mirror.ox.ac.uk/sites/ctan.org/systems/texlive/tlnet
+ARG TEXLIVE_MIRROR=https://ctan.crest.fr/tex-archive/systems/texlive/tlnet
 
 RUN mkdir /install-tl-unx
-RUN wget --quiet https://tug.org/texlive/files/texlive.asc
+RUN wget https://tug.org/texlive/files/texlive.asc
 RUN gpg --import texlive.asc
-RUN  rm texlive.asc
-RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz
-RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512
-RUN  wget --quiet ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc
-RUN  gpg --verify install-tl-unx.tar.gz.sha512.asc
-RUN  sha512sum -c install-tl-unx.tar.gz.sha512
-RUN  tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz
-RUN  rm install-tl-unx.tar.gz*
-RUN  echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile
-RUN  echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile
-RUN  echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile
-RUN  echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
-RUN  /install-tl-unx/install-tl \
+RUN rm texlive.asc
+RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz
+RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512
+RUN wget ${TEXLIVE_MIRROR}/install-tl-unx.tar.gz.sha512.asc
+RUN gpg --verify install-tl-unx.tar.gz.sha512.asc
+RUN sha512sum -c install-tl-unx.tar.gz.sha512
+RUN tar -xz -C /install-tl-unx --strip-components=1 -f install-tl-unx.tar.gz
+RUN rm install-tl-unx.tar.gz*
+RUN echo "tlpdbopt_autobackup 0" >> /install-tl-unx/texlive.profile
+RUN echo "tlpdbopt_install_docfiles 0" >> /install-tl-unx/texlive.profile
+RUN echo "tlpdbopt_install_srcfiles 0" >> /install-tl-unx/texlive.profile
+RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile
+RUN /install-tl-unx/install-tl \
       -profile /install-tl-unx/texlive.profile \
       -repository ${TEXLIVE_MIRROR}
-RUN  $(find /usr/local/texlive -name tlmgr) path add
-RUN  tlmgr install --repository ${TEXLIVE_MIRROR} \
+RUN $(find /usr/local/texlive -name tlmgr) path add
+RUN tlmgr install --repository ${TEXLIVE_MIRROR} \
       latexmk \
       texcount \
       synctex \
       etoolbox \
       xetex
-RUN  tlmgr path add
-RUN  rm -rf /install-tl-unx
+RUN tlmgr path add
+RUN rm -rf /install-tl-unx
 
 
 # Set up overleaf user and home directory

--- a/server-ce/Dockerfile-base
+++ b/server-ce/Dockerfile-base
@@ -42,7 +42,7 @@ RUN apt-get update \
 # # docker build \
 #     --build-arg TEXLIVE_MIRROR=https://ctan.crest.fr/tex-archive/systems/texlive/tlnet \
 #     -f Dockerfile-base -t sharelatex/sharelatex-base .
-ARG TEXLIVE_MIRROR=https://ctan.crest.fr/tex-archive/systems/texlive/tlnet
+ARG TEXLIVE_MIRROR=https://mirror.ox.ac.uk/sites/ctan.org/systems/texlive/tlnet
 
 RUN mkdir /install-tl-unx \
 &&  wget --quiet https://tug.org/texlive/files/texlive.asc \

--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -345,10 +345,15 @@ if (process.env.OVERLEAF_EMAIL_FROM_ADDRESS != null) {
       // SMTP Creds
       host: process.env.OVERLEAF_EMAIL_SMTP_HOST,
       port: process.env.OVERLEAF_EMAIL_SMTP_PORT,
-      secure: parse(process.env.OVERLEAF_EMAIL_SMTP_SECURE),
-      ignoreTLS: parse(process.env.OVERLEAF_EMAIL_SMTP_IGNORE_TLS),
+      secure: parse(process.env.OVERLEAF_EMAIL_SMTP_SECURE || 'true'),
+      ignoreTLS: parse(process.env.OVERLEAF_EMAIL_SMTP_IGNORE_TLS || 'false'),
+      tls: {
+        rejectUnauthorized: parse(
+          process.env.OVERLEAF_EMAIL_SMTP_TLS_REJECT_UNAUTH || 'true'
+        )
+      },
       name: process.env.OVERLEAF_EMAIL_SMTP_NAME,
-      logger: process.env.OVERLEAF_EMAIL_SMTP_LOGGER === 'true',
+      logger: parse(process.env.OVERLEAF_EMAIL_SMTP_LOGGER || 'false'),
     },
 
     textEncoding: process.env.OVERLEAF_EMAIL_TEXT_ENCODING,
@@ -368,14 +373,6 @@ if (process.env.OVERLEAF_EMAIL_FROM_ADDRESS != null) {
     settings.email.parameters.auth = {
       user: process.env.OVERLEAF_EMAIL_SMTP_USER,
       pass: process.env.OVERLEAF_EMAIL_SMTP_PASS,
-    }
-  }
-
-  if (process.env.OVERLEAF_EMAIL_SMTP_TLS_REJECT_UNAUTH != null) {
-    settings.email.parameters.tls = {
-      rejectUnauthorized: parse(
-        process.env.OVERLEAF_EMAIL_SMTP_TLS_REJECT_UNAUTH
-      ),
     }
   }
 }

--- a/services/web/app/src/Features/Email/EmailSender.js
+++ b/services/web/app/src/Features/Email/EmailSender.js
@@ -48,6 +48,7 @@ function getClient() {
         'secure',
         'auth',
         'ignoreTLS',
+        'tls',
         'logger',
         'name'
       )


### PR DESCRIPTION
## Description
The `OVERLEAF_EMAIL_SMTP_TLS_REJECT_UNAUTH` is used to set `settings.email.parameters.tls.rejectUnauthorized` in `settings.js` which allows for using self-signed certificates when connecting to smtp email servers. However, the `tls` parameter is never read out when instantiating the mailer client. This PR fixes this issue. 


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->
fixes issue  #1195

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
