### PR TITLE
fix ipv6 docker 26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
                 condition: service_started
         ports:
             - 80:80
+        sysctls:
+            - net.ipv6.conf.all.disable_ipv6=1    
         links:
             - mongo
             - redis


### PR DESCRIPTION
## Description
fix ipv6 container error after docker 26 update 

error : 
curl http://127.0.0.1:4000
curl: (7) Failed to connect to 127.0.0.1 port 4000: Connection refused

For information, I tried to replace 127.0.0.1 with localhost in /etc/nginx/sites-enabled/sharelatex.conf, the service started, but there were problems when I wanted to edit a project.


## Related issues / Pull Requests
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
