### PR TITLE
Docker Compose: remove obsolete version

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
     sharelatex:
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
     sharelatex:
         restart: always


### PR DESCRIPTION
Remove docker compose version since it is now obsolete.

See also: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete