### PR TITLE
outline: handle texorpdfstring command.

### DIFF
--- a/services/web/frontend/js/features/source-editor/utils/tree-operations/outline.ts
+++ b/services/web/frontend/js/features/source-editor/utils/tree-operations/outline.ts
@@ -88,6 +88,23 @@ const getEntryText = (state: EditorState, node: SyntaxNodeRef): string => {
       return false
     }
 
+    // Handle the texorpdfstring command
+    if (
+      token.type.name === 'Command' &&
+      token.node.firstChild?.firstChild != null
+    ) {
+      let command = token.node.firstChild.firstChild
+      let commandName = state.doc.sliceString(command.from + 1, command.to)
+      let textArguments = token.node.firstChild.getChildren('TextArgument')
+      if (commandName == 'texorpdfstring' && textArguments.length >= 2) {
+        let pdfstring = textArguments[1]
+        titleParts.push(
+          state.doc.sliceString(pdfstring.from + 1, pdfstring.to - 1)
+        )
+        return false
+      }
+    }
+
     // Only add text from leaf nodes
     if (token.node.firstChild) {
       return true

--- a/services/web/test/frontend/features/source-editor/languages/latex/latex-outline.test.ts
+++ b/services/web/test/frontend/features/source-editor/languages/latex/latex-outline.test.ts
@@ -449,6 +449,29 @@ describe('CodeMirror LaTeX-FileOutline', function () {
     })
   })
 
+  describe('for labels using texorpdfstring', function () {
+    let view: EditorView, content: string[]
+    beforeEach(function () {
+      content = [
+        '\\section{The \\texorpdfstring{function $f(x) = x^2$}{function f(x) = x^2}: Properties of \\texorpdfstring{$x$}{x}.}',
+      ]
+      view = makeView(content)
+    })
+
+    it('should use the text argument as title', function () {
+      const outline = getOutline(view)
+      expect(outline).to.deep.equal([
+        {
+          from: 0,
+          to: 113,
+          title: 'The function f(x) = x^2: Properties of x.',
+          line: 1,
+          level: SECTION_LEVEL,
+        },
+      ])
+    })
+  })
+
   describe('for ill-formed \\def command', function () {
     let view: EditorView, content: string[]
     beforeEach(function () {


### PR DESCRIPTION
## Description
This handles the command `texorpdfstring` in outline titles


## Related issues / Pull Requests
https://github.com/overleaf/overleaf/issues/1037


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
