### PR TITLE
launchpad: Fix `Status Check` for `Editor Resources`

### DIFF
--- a/services/web/modules/launchpad/app/views/launchpad.pug
+++ b/services/web/modules/launchpad/app/views/launchpad.pug
@@ -28,7 +28,7 @@ block vars
 
 block append meta
 	meta(name="ol-adminUserExists" data-type="boolean" content=adminUserExists)
-	meta(name="ol-ideJsPath" content=buildJsPath('ide.js'))
+	meta(name="ol-ideJsPath" content=buildJsPath('ide-detached.js'))
 
 block content
 	script(type="text/javascript", nonce=scriptNonce, src=(wsUrl || '/socket.io') + '/socket.io.js')


### PR DESCRIPTION
## Description
The old IDE has been removed:
https://github.com/overleaf/overleaf/commit/c24ace801bf7e3a5475903c2fa7125e8cf3d7e28#diff-f664a365607494e60c8e2f1df05e1ac5adaed2873807673ad83e206c56c1116bL24

However, the status check for `Editor Resources` on `/launchpad` tries to fetch the old (non-existant) `ide.js` to verify that everything is working correctly. As this file does not exist on later versions, for example `7.1.0`, it cannot be found in the manifest and the check tries to fetch `/undefined` instead, resulting in a `404`.

Instead of checking for `ide.js`, we should just check for `ide-detached.js`, which still exists and is properly listed in the manifest.

## Related issues / Pull Requests
Adjustments neccessary after commit:
https://github.com/overleaf/overleaf/commit/c24ace801bf7e3a5475903c2fa7125e8cf3d7e28

Relates to internal PR:
#17534

Closes https://github.com/overleaf/toolkit/issues/271


## Contributor Agreement

- [X] I am not willing to sign the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
(why should I submit my full legal information there?)

I'm happy to release this one-line-change to everyone without reserving any rights for myself. I do not take any warranty or responsibility for this change. If signing the agreement is absolutely neccessary, feel free to find someone else to re-submit this simple change as PR under any license/agreement on their matter.