### PR TITLE
docker-compose: Replace deprecated `mongo` with `mongosh`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
           # This override is not needed when running the setup after starting up mongo.
           - mongo:127.0.0.1
         healthcheck:
-            test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+            test: echo 'db.stats().ok' | mongosh localhost:27017/test --quiet
             interval: 10s
             timeout: 10s
             retries: 5


### PR DESCRIPTION
## Description
This replaces the deprecated `mongo` command with `mongosh`.
The `mongo` command has been removed in the docker 6.0 images, causing the health check to fail:
```
$ docker run --rm -it mongo:6.0 /bin/bash
root@88fd1ef0efd0:/# mongo
bash: mongo: command not found
root@88fd1ef0efd0:/# mongosh --version
2.3.8
```


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
