### PR TITLE
Add message to docker-compose.yml file prompting CE deployments to comment out SP default envs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,12 @@ services:
             ################
             ## Server Pro ##
             ################
-
-            ## Sandboxed Compiles: https://github.com/overleaf/overleaf/wiki/Server-Pro:-Sandboxed-Compiles
+            
+            ## The Community Edition is intended for use in environments where all users are trusted and is not appropriate for
+            ## scenarios where isolation of users is required. Sandboxed Compiles are not available in the Community Edition,
+            ## so the following environment variables must be commented out to avoid compile issues.
+            ##
+            ## Sandboxed Compiles: https://docs.overleaf.com/on-premises/configuration/overleaf-toolkit/server-pro-only-configuration/sandboxed-compiles
             SANDBOXED_COMPILES: 'true'
             ### Bind-mount source for /var/lib/overleaf/data/compiles inside the container.
             SANDBOXED_COMPILES_HOST_DIR_COMPILES: '/home/user/sharelatex_data/data/compiles'


### PR DESCRIPTION
## Description
The Community Edition is intended for use in environments where all users are trusted. The [docker-compose.yml](https://github.com/overleaf/overleaf/blob/main/docker-compose.yml) file's default settings are secure by design, resulting in projects being compiled in sandboxed containers for enterprise security. Commenting out the required lines could lead to Server Pro deployments with reduced security, which is something we would want to avoid.

This commit updates the link to the new Sandboxed Compiles documentation and adds a message prompting CE deployments to comment out the necessary SP default environment variables.

## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
