### PR TITLE
Easily selectable Insert Figure automatic label

### DIFF
--- a/services/web/frontend/js/features/source-editor/components/figure-modal/figure-modal.tsx
+++ b/services/web/frontend/js/features/source-editor/components/figure-modal/figure-modal.tsx
@@ -155,7 +155,7 @@ const FigureModalContent = () => {
       dispatch({ error: String(error) })
       return
     }
-    const labelCommand = includeLabel ? '\\label{fig:enter-label}' : ''
+    const labelCommand = includeLabel ? '\\label{fig:enter_label}' : ''
     const captionCommand = includeCaption ? '\\caption{Enter Caption}' : ''
 
     if (figure) {
@@ -228,7 +228,7 @@ const FigureModalContent = () => {
       const widthArgument =
         width !== undefined ? `[width=${width}\\linewidth]` : ''
       const caption = includeCaption ? `\n\t\\caption{\${Enter Caption}}` : ''
-      const label = includeLabel ? `\n\t\\label{\${fig:enter-label}}` : ''
+      const label = includeLabel ? `\n\t\\label{\${fig:enter_label}}` : ''
 
       snippet(
         `\\begin{figure}

--- a/services/web/frontend/js/features/source-editor/languages/latex/completions/data/environments.ts
+++ b/services/web/frontend/js/features/source-editor/languages/latex/completions/data/environments.ts
@@ -39,7 +39,7 @@ export const environments = new Map([
 \t\\centering
 \t\\includegraphics[width=0.5\\linewidth]{$1}
 \t\\caption{\${2:Caption}}
-\t\\label{\${3:fig:enter-label}}
+\t\\label{\${3:fig:enter_label}}
 \\end{figure}`,
   ],
   [

--- a/services/web/test/frontend/features/source-editor/components/codemirror-editor-figure-modal.spec.tsx
+++ b/services/web/test/frontend/features/source-editor/components/codemirror-editor-figure-modal.spec.tsx
@@ -108,7 +108,7 @@ describe('<FigureModal />', function () {
 
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter_label\\end{figure}'
       )
     })
 
@@ -154,7 +154,7 @@ describe('<FigureModal />', function () {
       cy.findByRole('button', { name: 'Insert figure' }).click()
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter_label\\end{figure}'
       )
     })
   })
@@ -240,7 +240,7 @@ describe('<FigureModal />', function () {
 
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter_label\\end{figure}'
       )
     })
 
@@ -267,7 +267,7 @@ describe('<FigureModal />', function () {
 
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter_label\\end{figure}'
       )
     })
   })
@@ -411,7 +411,7 @@ describe('<FigureModal />', function () {
 
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{Enter Caption}    🏷fig:enter_label\\end{figure}'
       )
     })
 
@@ -437,7 +437,7 @@ describe('<FigureModal />', function () {
       cy.focused().type('My caption')
       cy.get('.cm-content').should(
         'have.text',
-        '\\begin{figure}    \\centering    \\caption{My caption}    🏷fig:enter-label\\end{figure}'
+        '\\begin{figure}    \\centering    \\caption{My caption}    🏷fig:enter_label\\end{figure}'
       )
     })
 


### PR DESCRIPTION
## Description
Change automatic label from "fig:enter-label" to "fig:enter_label" such that it can be selected by double-click.


## Related issues / Pull Requests
Fixes #1365.


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
