### PR TITLE
Create Bug template in the ISSUE_TEMPLATE folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a bug
+title: ''
+labels: type:bug
+assignees: ''
+
+---
+
+<!--
+
+Note: If you are using www.overleaf.com and have a problem, 
+      or if you would like to request a new feature please contact
+      the support team at support@overleaf.com
+      
+      This form should only be used to report bugs in the 
+      Community Edition release of Overleaf.
+
+-->
+
+
+
+<!-- BUG REPORT TEMPLATE -->
+
+## Steps to Reproduce
+<!-- Describe the steps leading up to when / where you found the bug. -->
+<!-- Screenshots may be helpful here. -->
+
+1.
+2.
+3.
+
+## Expected Behaviour
+<!-- What should have happened when you completed the steps above? -->
+
+## Observed Behaviour
+<!-- What actually happened when you completed the steps above? -->
+<!-- Screenshots may be helpful here. -->
+
+## Context
+<!-- How has this issue affected you? What were you trying to accomplish? -->
+
+## Technical Info
+<!-- Provide any technical details that may be applicable (or N/A if not applicable). -->
+
+* URL:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Signed in as:
+* Project and/or file:
+
+## Analysis
+<!--- Optionally, document investigation of / suggest a fix for the bug, e.g. 'comes from this line / commit' -->


### PR DESCRIPTION
## Description

Our issue ticket is an empty template, and I think this is because the version is outdated.

> Warning: You are using an old version of issue templates. Please update to the new issue template workflow.
> [Learn more about issue templates]( https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)

**Changes:** I am creating the template, because issue templates have to be located in the `.github/ISSUE_TEMPLATE` folder the same was as in our internal repo.

If this is approved, we should delete https://github.com/overleaf/overleaf/blob/main/.github/ISSUE_TEMPLATE.md
