### PR TITLE
Fix naming collision in manual compile for subdirectory files

### DIFF
--- a/services/clsi/app/js/CompileManager.js
+++ b/services/clsi/app/js/CompileManager.js
@@ -142,6 +142,17 @@ async function doCompile(request, stats, timings) {
     // override default texlive max_print_line environment variable
     env.max_print_line = Settings.texliveMaxPrintLine
   }
+
+  // Fix for subdirectory compilation: configure TEXINPUTS to resolve relative paths.
+  // When compiling files in subdirectories (part of fix for issue #1374), we need
+  // to ensure LaTeX can find relative includes/graphics from the file's directory.
+  if (request.rootResourcePath && request.rootResourcePath.includes('/')) {
+    const relDir = Path.dirname(request.rootResourcePath)
+    // Set TEXINPUTS to search recursively in the file's directory first.
+    // The '//' suffix enables recursive search, ':' separates paths (kpsewhich format)
+    const texinputsPrefix = `${relDir}//:`
+    env.TEXINPUTS = env.TEXINPUTS ? `${texinputsPrefix}${env.TEXINPUTS}` : texinputsPrefix
+  }
   // only run chktex on LaTeX files (not knitr .Rtex files or any others)
   const isLaTeXFile = request.rootResourcePath?.match(/\.tex$/i)
   if (request.check != null && isLaTeXFile) {

--- a/services/clsi/app/js/LatexRunner.js
+++ b/services/clsi/app/js/LatexRunner.js
@@ -153,10 +153,23 @@ function _buildLatexCommand(mainFile, opts = {}) {
     command.push(...Settings.clsi.latexmkCommandPrefix)
   }
 
+  // Detect if main file is in a subdirectory to handle naming collisions
+  const mainFileDir = Path.dirname(mainFile)
+  const isInSubdir = mainFileDir !== '.'
+
   // Basic command and flags
+  command.push('latexmk')
+
+  // Fix for naming collision bug: only use -cd flag for root-level files.
+  // When compiling subdirectory files (e.g., folder/main.tex), the -cd flag causes
+  // latexmk to incorrectly resolve paths when identical filenames exist at multiple
+  // levels. For subdirectory files, we stay in /compile and rely on TEXINPUTS
+  // (configured in CompileManager) to resolve relative paths correctly.
+  if (!isInSubdir) {
+    command.push('-cd')
+  }
+  
   command.push(
-    'latexmk',
-    '-cd',
     '-jobname=output',
     '-auxdir=$COMPILE_DIR',
     '-outdir=$COMPILE_DIR',


### PR DESCRIPTION
## Description
When compiling files in subdirectories with identical names to root files (e.g., folder/main.tex when main.tex exists in root), latexmk would incorrectly compile the root file due to path confusion with the -cd flag.

Changes:
- LatexRunner: Skip -cd flag for subdirectory files to prevent path confusion
- CompileManager: Set TEXINPUTS to enable relative path resolution for subdirectory files

This ensures folder/main.tex compiles the correct file while maintaining compatibility with relative includes/graphics.

## Related issues / Pull Requests
Fixes #1374


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
