### PR TITLE
Make review-mode-switcher turn transparent when dragging

### DIFF
--- a/services/web/frontend/js/features/review-panel/components/review-mode-switcher.tsx
+++ b/services/web/frontend/js/features/review-panel/components/review-mode-switcher.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, MouseEventHandler, useState } from 'react'
+import { forwardRef, memo, MouseEventHandler, useEffect, useState } from 'react'
 import {
   Dropdown,
   DropdownMenu,
@@ -53,11 +53,30 @@ function ReviewModeSwitcher() {
   const { write, trackedWrite } = usePermissionsContext()
   const { features } = useProjectContext()
   const [showUpgradeModal, setShowUpgradeModal] = useState(false)
+  // Track global drag to avoid the button covering text (opacity changes while dragging)
+  const [isDragging, setIsDragging] = useState(false)
   const showViewOption = permissionsLevel === 'readOnly'
   const view = useCodeMirrorViewContext()
 
+  useEffect(() => {
+    const handleMouseDown = () => setIsDragging(true)
+    const handleMouseUp = () => setIsDragging(false)
+
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [])
+
   return (
-    <div className="review-mode-switcher-container">
+    <div
+      className={classNames('review-mode-switcher-container', {
+        'review-mode-switcher-dragging': isDragging,
+      })}
+    >
       <Dropdown className="review-mode-switcher" align="end">
         <DropdownToggle
           as={ModeSwitcherToggleButton}

--- a/services/web/frontend/stylesheets/pages/editor/review-panel.scss
+++ b/services/web/frontend/stylesheets/pages/editor/review-panel.scss
@@ -782,3 +782,7 @@ del.review-panel-content-highlight {
     }
   }
 }
+
+.review-mode-switcher-dragging:hover {
+  opacity: 0.25;
+}


### PR DESCRIPTION
## Description
Make the editing button on the text editor turn transparent when dragging the mouse, making it easier to select the characters under the button.

## Related issues / Pull Requests
Fixes #1361

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)

After change
<img width="763" height="112" alt="image" src="https://github.com/user-attachments/assets/77c68c62-5b33-4ad8-bed5-8a910cb8b129" />

Before change
<img width="825" height="144" alt="image" src="https://github.com/user-attachments/assets/5419c4f4-a64e-4251-8dd3-83a3a876896b" />


