### PR TITLE
Add eslint-plugin library package (Fixes Issues #1415)

### DIFF
--- a/libraries/eslint-plugin/package.json
+++ b/libraries/eslint-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@overleaf/eslint-plugin",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "dependencies": {
+    "eslint": "^8.51.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@typescript-eslint/parser": "^8.30.1"
+  }
+}


### PR DESCRIPTION
## Problem Description
As reported in #1415, the repository references `libraries/eslint-plugin/` in build configuration and package lock file, but this directory does not exist, causing Docker build failures with:
  `ERROR: failed to calculate checksum of ref .../libraries/eslint-plugin: not found`

## Solution
Create initial package.json for @overleaf/eslint-plugin library to support ESLint plugin development within the Overleaf monorepo workspace structure. This establishes the foundation for custom ESLint rules and configurations that can be shared across services.

## Related issues / Pull Requests
Fixes Issues #1415 


## Contributor Agreement

- [√] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
