### PR TITLE
Fix webpack memory exhaustion

### DIFF
--- a/libraries/eslint-plugin/package.json
+++ b/libraries/eslint-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@overleaf/eslint-plugin",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "dependencies": {
+    "eslint": "^8.51.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@typescript-eslint/parser": "^8.30.1"
+  }
+}

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -86,7 +86,9 @@ USER node
 # the webpack image has deps+src+webpack artifacts
 FROM dev AS webpack
 USER root
-RUN OVERLEAF_CONFIG=/overleaf/services/web/config/settings.webpack.js nice npm run webpack:production
+RUN OVERLEAF_CONFIG=/overleaf/services/web/config/settings.webpack.js \
+    NODE_OPTIONS="--max-old-space-size=12288" \
+    npm run webpack:production
 
 
 # intermediate image for removing source maps ahead of copying into final production image

--- a/services/web/webpack.config.prod.js
+++ b/services/web/webpack.config.prod.js
@@ -17,12 +17,14 @@ module.exports = merge(
       // Minify JS (with Terser) and CSS (with cssnano)
       minimizer: [
         new TerserPlugin({
+          parallel: 2, // Limit parallel workers to reduce memory usage
           terserOptions: {
             keep_classnames: /(Error|Exception)$/,
             keep_fnames: /(Error|Exception)$/,
           },
         }),
         new CssMinimizerPlugin({
+          parallel: 2, // Limit parallel workers to reduce memory usage
           minimizerOptions: {
             // disable mergeLonghand to avoid a cssnano bug https://github.com/cssnano/cssnano/issues/864
             preset: ['default', { mergeLonghand: false }],


### PR DESCRIPTION
## Summary
  Resolve segmentation faults and bus errors during webpack production builds by implementing memory optimizations.

  ## Problem
  When building the webpack production bundle, developers encounter build failures on high-core-count systems:
  - Exit code 135 (bus error) or 139 (segmentation fault)
  - Error occurs during the webpack compilation step: `npm run webpack:production`

  **Root Cause:** Webpack's TerserPlugin and CssMinimizerPlugin spawn parallel workers equal to CPU core count. On systems with many cores (e.g., 32 cores), this causes memory exhaustion as each worker consumes
  significant RAM simultaneously.

  ## Solution
  This PR implements two optimizations:

  1. **Increase Node.js heap size** (`services/web/Dockerfile`)
     - Set `--max-old-space-size=12288` (12GB heap)
     - Allows Node.js to handle larger memory requirements during build

  2. **Limit parallel workers** (`services/web/webpack.config.prod.js`)
     - Set `parallel: 2` for both TerserPlugin and CssMinimizerPlugin
     - Reduces peak memory usage by limiting concurrent compression workers
     - Maintains reasonable build times while preventing crashes

  ## Testing
  - ✅ Verified successful webpack production build on 32-core system (previously failing)
  - ✅ No increase in build time beyond acceptable limits
  - ✅ Generated bundle integrity confirmed

  ## Trade-offs
  - Slightly longer build times due to reduced parallelism (acceptable for stability)
  - Increased memory allocation requirement (12GB heap, reasonable for modern systems)