### PR TITLE
chore: define image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     restart: always
     # Server Pro users:
     # image: quay.io/sharelatex/sharelatex-pro
-    image: sharelatex/sharelatex
+    image: sharelatex/sharelatex:6.1.1
     container_name: sharelatex
     depends_on:
       mongo:
@@ -103,7 +103,7 @@ services:
 
   mongo:
     restart: always
-    image: mongo:6.0
+    image: mongo:8.2
     container_name: mongo
     command: "--replSet overleaf"
     volumes:
@@ -123,7 +123,7 @@ services:
 
   redis:
     restart: always
-    image: redis:6.2
+    image: redis:8-alpine
     container_name: redis
     volumes:
       - ~/redis_data:/data


### PR DESCRIPTION
- bumps mongo to 8.2 as required by modern sharelatext versions
- bumps redis to 8 in minimal alpine version
- defines latest sharelatext image tag

## Description

The compose stack does not properly spawn up as sharelatex requires mongo >= 8.

The container throws the following error:

````
The MongoDB server has version X, but Overleaf requires at least version 8.0. Aborting.
````
Introduced by [check-mongodb.mjs](https://github.com/overleaf/overleaf/blob/main/services/web/modules/server-ce-scripts/scripts/check-mongodb.mjs#L108).

@das7pad & @aeaton-overleaf

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
