### PR TITLE
fix: use result of replace method in sanitize.js

### DIFF
--- a/services/web/scripts/translations/sanitize.js
+++ b/services/web/scripts/translations/sanitize.js
@@ -11,7 +11,7 @@ function sanitize(input) {
   // Ticket: https://github.com/overleaf/issues/issues/4478
   input = input.replace(/'/g, '’')
   // Use left quote where (likely) appropriate.
-  input.replace(/ ’/g, ' ‘')
+  input = input.replace(/ ’/g, ' ‘')
 
   // Allow "replacement" tags (in the format <0>, <1>, <2>, etc) used by
   // react-i18next to allow for HTML insertion via the Trans component.


### PR DESCRIPTION
Hello,
As a result of analyzing your project with the PVS-Studio static analyzer, we found the following error in your code. In the second method line, input may be replaced in an incorrect way because the right single quotation mark is not replaced. In this PR, we fix that.


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)