### PR TITLE
fix: chown /var/lib/overleaf mount point to www-data

### DIFF
--- a/server-ce/init_scripts/100_make_overleaf_data_dirs.sh
+++ b/server-ce/init_scripts/100_make_overleaf_data_dirs.sh
@@ -2,6 +2,7 @@
 set -e
 
 mkdir -p /var/lib/overleaf/data
+chown www-data:www-data /var/lib/overleaf
 chown www-data:www-data /var/lib/overleaf/data
 
 mkdir -p /var/lib/overleaf/data/compiles


### PR DESCRIPTION
## Description

The init script chowns all subdirectories but not the mount point itself. When the host volume is owned by a non-www-data user with restrictive permissions (e.g. 770), the web process cannot traverse the directory and crashes with EACCES, causing a 502.

## Related issues / Pull Requests

Fixes #1325 and #1465

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
