### PR TITLE
fix: conditionally show items in `insert figure` toolbar

### DIFF
--- a/services/web/frontend/js/features/source-editor/hooks/use-toolbar-menu-editor-commands.tsx
+++ b/services/web/frontend/js/features/source-editor/hooks/use-toolbar-menu-editor-commands.tsx
@@ -36,6 +36,12 @@ export const useToolbarMenuBarEditorCommands = () => {
     )
   }, [])
 
+  const {
+    hasLinkedProjectFileFeature,
+    hasLinkedProjectOutputFileFeature,
+    hasLinkUrlFeature,
+  } = getMeta('ol-ExposedSettings')
+
   useCommandProvider(() => {
     if (!editorIsVisible) {
       return
@@ -124,14 +130,14 @@ export const useToolbarMenuBarEditorCommands = () => {
           openFigureModal(FigureModalSource.FILE_TREE)
         },
       },
-      {
+      (hasLinkedProjectFileFeature || hasLinkedProjectOutputFileFeature) && {
         label: t('from_another_project'),
         id: 'insert-figure-from-another-project',
         handler: () => {
           openFigureModal(FigureModalSource.OTHER_PROJECT)
         },
       },
-      {
+      hasLinkUrlFeature && {
         label: t('from_url'),
         id: 'insert-figure-from-url',
         handler: () => {
@@ -287,6 +293,9 @@ export const useToolbarMenuBarEditorCommands = () => {
     isTeXFile,
     canComment,
     comment,
+    hasLinkedProjectFileFeature,
+    hasLinkedProjectOutputFileFeature,
+    hasLinkUrlFeature,
   ])
 
   const { toggleSymbolPalette } = useEditorPropertiesContext()


### PR DESCRIPTION
## Description

Removes the options for inserting an image from another project or by downloading an external URL, if this feature has been determined to be disabled by the lack of configuration.

The conditions have been copied from [insert-figure-dropdown.tsx](https://github.com/overleaf/overleaf/blob/main/services/web/frontend/js/features/source-editor/components/toolbar/insert-figure-dropdown.tsx)

## Related issues / Pull Requests

In the community issue, `linkedUrlProxy` cannot be configured. Therefore, trying to download any image from an external URL fails through trying to read `linkedUrlProxy.url` with `linkedUrlProxy=undefined` in [UrlHelper.mjs](https://github.com/overleaf/overleaf/blob/main/services/web/app/src/Features/Helpers/UrlHelper.mjs). However, this window and configuration should not even be accessible in this case, which is fixed in this PR.

## Contributor Agreement

I am hereby signing off all my copyrights and declare this patch to be in the public domain (CC0). I don't plan on signing your contribution agreement, but please fix your code anyways.