### PR TITLE
Upgrade MongoDB image from 6.0 to 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   mongo:
     restart: always
-    image: mongo:6.0
+    image: mongo:8.0
     container_name: mongo
     command: "--replSet overleaf"
     volumes:


### PR DESCRIPTION
## Description

Fixes: sharelatex  | The MongoDB server has version 6.0.27, but Overleaf requires at least version 8.0. Aborting.

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
