### PR TITLE
fix: name downloaded PDF after main document instead of project

### DIFF
--- a/services/web/app/src/Features/Compile/CompileController.mjs
+++ b/services/web/app/src/Features/Compile/CompileController.mjs
@@ -1,6 +1,10 @@
+import { URL } from 'node:url'
 import { pipeline } from 'node:stream/promises'
+import { Cookie } from 'tough-cookie'
+import OError from '@overleaf/o-error'
 import Metrics from '@overleaf/metrics'
 import ProjectGetter from '../Project/ProjectGetter.mjs'
+import ProjectLocator from '../Project/ProjectLocator.mjs'
 import CompileManager from './CompileManager.mjs'
 import ClsiManager from './ClsiManager.mjs'
 import logger from '@overleaf/logger'
@@ -9,6 +13,7 @@ import Errors from '../Errors/Errors.js'
 import SessionManager from '../Authentication/SessionManager.mjs'
 import { RateLimiter } from '../../infrastructure/RateLimiter.mjs'
 import Validation from '../../infrastructure/Validation.mjs'
+import ClsiCookieManagerFactory from './ClsiCookieManager.mjs'
 import Path from 'node:path'
 import AnalyticsManager from '../Analytics/AnalyticsManager.mjs'
 import SplitTestHandler from '../SplitTests/SplitTestHandler.mjs'
@@ -18,18 +23,13 @@ import {
   RequestFailedError,
 } from '@overleaf/fetch-utils'
 import Features from '../../infrastructure/Features.mjs'
-import ClsiCacheController from './ClsiCacheController.mjs'
-import { prepareZipAttachment } from '../../infrastructure/Response.mjs'
-import ClsiCacheHandler from './ClsiCacheHandler.mjs'
-import {
-  getFilePath,
-  getOutputFileURL,
-  getOutputZipURL,
-} from './ClsiURLHelpers.mjs'
 
 const { z, zz, parseReq } = Validation
+const ClsiCookieManager = ClsiCookieManagerFactory(
+  Settings.apis.clsi?.backendGroupName
+)
 
-const COMPILE_TIMEOUT_MS = 12 * 60 * 1000
+const COMPILE_TIMEOUT_MS = 10 * 60 * 1000
 
 const pdfDownloadRateLimiter = new RateLimiter('full-pdf-download', {
   points: 1000,
@@ -40,19 +40,23 @@ function getOutputFilesArchiveSpecification(projectId, userId, buildId) {
   const fileName = 'output.zip'
   return {
     path: fileName,
-    url: getFilePath(projectId, userId, buildId, fileName),
+    url: _CompileController._getFileUrl(projectId, userId, buildId, fileName),
     type: 'zip',
   }
 }
 
-async function _getSplitTestOptions(req, res) {
-  const { variant } = await SplitTestHandler.promises.getAssignment(
-    req,
-    res,
-    'compile-from-history',
-    { includeReferer: true }
-  )
-  const compileFromHistory = variant === 'enabled'
+function getPdfCachingMinChunkSize(req, res) {
+  return Settings.pdfCachingMinChunkSize
+}
+
+function _getSplitTestOptions(req, res) {
+  // Use the query flags from the editor request for overriding the split test.
+  let query = {}
+  try {
+    const u = new URL(req.headers.referer || req.url, Settings.siteUrl)
+    query = Object.fromEntries(u.searchParams.entries())
+  } catch (e) {}
+  const editorReq = { ...req, query }
 
   const pdfDownloadDomain = Settings.pdfDownloadDomain
   const enablePdfCaching = Settings.enablePdfCaching
@@ -60,15 +64,13 @@ async function _getSplitTestOptions(req, res) {
   if (!enablePdfCaching || !req.query.enable_pdf_caching) {
     // The frontend does not want to do pdf caching.
     return {
-      compileFromHistory,
       pdfDownloadDomain,
       enablePdfCaching: false,
     }
   }
 
-  const pdfCachingMinChunkSize = Settings.pdfCachingMinChunkSize
+  const pdfCachingMinChunkSize = getPdfCachingMinChunkSize(editorReq, res)
   return {
-    compileFromHistory,
     pdfDownloadDomain,
     enablePdfCaching,
     pdfCachingMinChunkSize,
@@ -105,7 +107,7 @@ const deleteAuxFilesSchema = z.object({
     Project_id: zz.objectId(),
   }),
   query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
+    clsiserverid: z.string().optional(),
   }),
 })
 
@@ -114,52 +116,8 @@ const wordCountSchema = z.object({
     Project_id: zz.objectId(),
   }),
   query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
+    clsiserverid: z.string().optional(),
     file: z.string().optional(),
-  }),
-})
-
-const getFileForSubmissionFromClsiSchema = z.object({
-  params: z.object({
-    submissionId: zz.submissionId(),
-    build_id: zz.buildId(),
-    file: zz.filepath(),
-  }),
-  query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
-  }),
-})
-
-const getFileFromClsiSchema = z.object({
-  params: z.object({
-    Project_id: zz.objectId(),
-    build_id: zz.buildId(),
-    file: zz.filepath(),
-  }),
-  query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
-    editorId: z.uuid().optional(),
-  }),
-})
-
-const getOutputPDFFromClsiSchema = z.object({
-  params: z.object({
-    Project_id: zz.objectId(),
-    build_id: zz.buildId(),
-  }),
-  query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
-    editorId: z.uuid().optional(),
-  }),
-})
-
-const getOutputZipFromClsiSchema = z.object({
-  params: z.object({
-    Project_id: zz.objectId(),
-    build_id: zz.buildId(),
-  }),
-  query: z.object({
-    clsiserverid: zz.clsiServerId().optional(),
   }),
 })
 
@@ -176,7 +134,6 @@ const _CompileController = {
       fileLineErrors,
       stopOnFirstError,
       editorId: req.body.editorId,
-      rootResourcePath: req.body.rootResourcePath,
     }
 
     if (req.body.rootDoc_id) {
@@ -201,38 +158,15 @@ const _CompileController = {
       options.incrementalCompilesEnabled = true
     }
 
-    let {
-      enablePdfCaching,
-      pdfCachingMinChunkSize,
-      pdfDownloadDomain,
-      compileFromHistory,
-    } = await _getSplitTestOptions(req, res)
+    let { enablePdfCaching, pdfCachingMinChunkSize, pdfDownloadDomain } =
+      _getSplitTestOptions(req, res)
     if (Features.hasFeature('saas')) {
       options.compileFromClsiCache = true
       options.populateClsiCache = true
-      options.compileFromHistory = compileFromHistory
     }
     options.enablePdfCaching = enablePdfCaching
     if (enablePdfCaching) {
       options.pdfCachingMinChunkSize = pdfCachingMinChunkSize
-    }
-
-    if (!options.rootResourcePath) {
-      const agent = (req.headers['user-agent'] || '').toLowerCase()
-      const isKnownOtherFrontend = agent.includes('node-fetch')
-      logger.warn(
-        { isKnownOtherFrontend, req, projectId, userId, options },
-        'rootResourcePath is missing in request body'
-      )
-      if (isKnownOtherFrontend) {
-        // Reject malformed compile request from "known" other frontend.
-        res.status(400).json({
-          error: 'rootResourcePath is missing in request body',
-        })
-        return
-      }
-      // All others: Log for now and fall back to old compile mode.
-      options.compileFromHistory = false
     }
 
     const {
@@ -361,30 +295,30 @@ const _CompileController = {
   },
 
   async downloadPdf(req, res) {
-    const {
-      params: { Project_id: projectId, build_id: buildId },
-      query: { clsiserverid: clsiServerId, editorId },
-    } = parseReq(req, getOutputPDFFromClsiSchema)
     Metrics.inc('pdf-downloads')
-    try {
-      await pdfDownloadRateLimiter.consume(req.ip, 1, { method: 'ip' })
-    } catch (err) {
-      if (err instanceof Error) {
-        logger.err({ err }, 'error checking rate limit for pdf download')
-        res.status(500).end()
-        return
-      }
-      logger.debug({ projectId, ip: req.ip }, 'rate limit hit downloading pdf')
-      res.status(429).end()
-      return
-    }
+    const projectId = req.params.Project_id
+    const rateLimit = () =>
+      pdfDownloadRateLimiter
+        .consume(req.ip, 1, { method: 'ip' })
+        .then(() => true)
+        .catch(err => {
+          if (err instanceof Error) {
+            throw err
+          }
+          return false
+        })
 
     const project = await ProjectGetter.promises.getProject(projectId, {
       name: 1,
+      rootDoc_id: 1,
+      rootFolder: 1,
     })
 
     res.contentType('application/pdf')
-    const filename = `${_CompileController._getSafeProjectName(project)}.pdf`
+    const filename = await _CompileController._getPdfDownloadFilename(
+      projectId,
+      project
+    )
 
     if (req.query.popupDownload) {
       res.setContentDisposition('attachment', { filename })
@@ -392,18 +326,36 @@ const _CompileController = {
       res.setContentDisposition('inline', { filename })
     }
 
-    const userId = CompileController._getUserIdForCompile(req)
-    await _downloadFromClsiNginx(
-      projectId,
-      userId,
-      editorId,
-      buildId,
-      'output.pdf',
-      clsiServerId,
-      'output-file',
-      req,
-      res
-    )
+    let canContinue
+    try {
+      canContinue = await rateLimit()
+    } catch (err) {
+      logger.err({ err }, 'error checking rate limit for pdf download')
+      res.sendStatus(500)
+      return
+    }
+
+    if (!canContinue) {
+      logger.debug({ projectId, ip: req.ip }, 'rate limit hit downloading pdf')
+      res.sendStatus(500) // should it be 429?
+    } else {
+      const userId = CompileController._getUserIdForCompile(req)
+
+      const url = _CompileController._getFileUrl(
+        projectId,
+        userId,
+        req.params.build_id,
+        'output.pdf'
+      )
+      await CompileController._proxyToClsi(
+        projectId,
+        'output-file',
+        url,
+        {},
+        req,
+        res
+      )
+    }
   },
 
   // Keep in sync with the logic for zip files in ProjectDownloadsController
@@ -411,12 +363,34 @@ const _CompileController = {
     return project.name.replace(/[^\p{L}\p{Nd}]/gu, '_')
   },
 
+  async _getPdfDownloadFilename(projectId, project) {
+    const fallback = `${_CompileController._getSafeProjectName(project)}.pdf`
+    if (project.rootDoc_id == null) {
+      return fallback
+    }
+    try {
+      const { element } = await ProjectLocator.promises.findRootDoc({
+        project_id: projectId,
+        project,
+      })
+      if (element?.name) {
+        const base = Path.basename(element.name, Path.extname(element.name))
+        return `${_CompileController._getSafeProjectName({ name: base })}.pdf`
+      }
+    } catch (err) {
+      logger.warn(
+        { err, projectId, rootDocId: project.rootDoc_id },
+        'failed to resolve root doc for pdf download filename'
+      )
+    }
+    return fallback
+  },
+
   async deleteAuxFiles(req, res) {
-    const {
-      params: { Project_id: projectId },
-      query: { clsiserverid },
-    } = parseReq(req, deleteAuxFilesSchema)
-    const userId = CompileController._getUserIdForCompile(req)
+    const { params, query } = parseReq(req, deleteAuxFilesSchema)
+    const projectId = params.Project_id
+    const { clsiserverid } = query
+    const userId = await CompileController._getUserIdForCompile(req)
     await CompileManager.promises.deleteAuxFiles(
       projectId,
       userId,
@@ -429,9 +403,9 @@ const _CompileController = {
   async compileAndDownloadPdf(req, res) {
     const projectId = req.params.project_id
 
-    let outputFiles, clsiServerId, buildId
+    let outputFiles
     try {
-      ;({ outputFiles, clsiServerId, buildId } = await CompileManager.promises
+      ;({ outputFiles } = await CompileManager.promises
         // pass userId as null, since templates are an "anonymous" compile
         .compile(projectId, null, {}))
     } catch (err) {
@@ -451,81 +425,77 @@ const _CompileController = {
       res.sendStatus(500)
       return
     }
-    await _downloadFromClsiNginx(
+    await CompileController._proxyToClsi(
       projectId,
-      null,
-      null,
-      buildId,
-      'output.pdf',
-      clsiServerId,
       'output-file',
-      req,
-      res
-    )
-  },
-
-  async getOutputZipFromClsi(req, res) {
-    const userId = CompileController._getUserIdForCompile(req)
-    const {
-      params: { Project_id: projectId, build_id: buildId },
-      query: { clsiserverid: clsiServerId },
-    } = parseReq(req, getOutputZipFromClsiSchema)
-
-    const project = await ProjectGetter.promises.getProject(projectId, {
-      name: 1,
-    })
-    const filename = `${_CompileController._getSafeProjectName(project)}-output.zip`
-    prepareZipAttachment(res, filename)
-
-    await _downloadFromClsi(
-      projectId,
-      userId,
-      null,
-      buildId,
-      'output.zip',
-      clsiServerId,
-      'output-zip-file',
+      pdf.url,
+      {},
       req,
       res
     )
   },
 
   async getFileFromClsi(req, res) {
+    const projectId = req.params.Project_id
     const userId = CompileController._getUserIdForCompile(req)
-    const {
-      params: { Project_id: projectId, build_id: buildId, file },
-      query: { clsiserverid: clsiServerId, editorId },
-    } = parseReq(req, getFileFromClsiSchema)
 
-    await _downloadFromClsiNginx(
+    const qs = {}
+
+    const url = _CompileController._getFileUrl(
       projectId,
       userId,
-      editorId,
-      buildId,
-      file,
-      clsiServerId,
+      req.params.build_id,
+      req.params.file
+    )
+    await CompileController._proxyToClsi(
+      projectId,
       'output-file',
+      url,
+      qs,
       req,
       res
     )
   },
 
-  async getFileForSubmissionFromClsi(req, res) {
-    const {
-      params: { submissionId, build_id: buildId, file },
-      query: { clsiserverid: clsiServerId },
-    } = parseReq(req, getFileForSubmissionFromClsiSchema)
-    await _downloadFromClsiNginx(
+  async getFileFromClsiWithoutUser(req, res) {
+    const submissionId = req.params.submission_id
+    const url = _CompileController._getFileUrl(
       submissionId,
       null,
-      null,
-      buildId,
-      file,
-      clsiServerId,
+      req.params.build_id,
+      req.params.file
+    )
+    const limits = {
+      compileGroup:
+        req.body?.compileGroup ||
+        req.query?.compileGroup ||
+        Settings.defaultFeatures.compileGroup,
+      compileBackendClass: Settings.apis.clsi.submissionBackendClass,
+    }
+    await CompileController._proxyToClsiWithLimits(
+      submissionId,
       'output-file',
+      url,
+      {},
+      limits,
       req,
       res
     )
+  },
+
+  // compute a GET file url for a given project, user (optional), build (optional) and file
+  _getFileUrl(projectId, userId, buildId, file) {
+    let url
+    if (userId != null && buildId != null) {
+      url = `/project/${projectId}/user/${userId}/build/${buildId}/output/${file}`
+    } else if (userId != null) {
+      url = `/project/${projectId}/user/${userId}/output/${file}`
+    } else if (buildId != null) {
+      url = `/project/${projectId}/build/${buildId}/output/${file}`
+    } else {
+      url = `/project/${projectId}/output/${file}`
+    }
+    return url
   },
 
   async proxySyncPdf(req, res) {
@@ -565,6 +535,125 @@ const _CompileController = {
     await _syncTeX(req, res, 'code', { file, line, column })
   },
 
+  async _proxyToClsi(projectId, action, url, qs, req, res) {
+    const limits =
+      await CompileManager.promises.getProjectCompileLimits(projectId)
+    return CompileController._proxyToClsiWithLimits(
+      projectId,
+      action,
+      url,
+      qs,
+      limits,
+      req,
+      res
+    )
+  },
+
+  async _proxyToClsiWithLimits(projectId, action, url, qs, limits, req, res) {
+    const persistenceOptions = await _getPersistenceOptions(
+      req,
+      projectId,
+      limits.compileGroup,
+      limits.compileBackendClass
+    ).catch(err => {
+      OError.tag(err, 'error getting cookie jar for clsi request')
+      throw err
+    })
+
+    url = new URL(`${Settings.apis.clsi.url}${url}`)
+
+    const searchParams = {
+      ...persistenceOptions.qs,
+      ...qs,
+    }
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (value !== undefined) {
+        // avoid sending "undefined" as a string value
+        url.searchParams.set(key, value)
+      }
+    }
+
+    const timer = new Metrics.Timer(
+      'proxy_to_clsi',
+      1,
+      { path: action },
+      [0, 100, 1000, 2000, 5000, 10000, 15000, 20000, 30000, 45000, 60000]
+    )
+    Metrics.inc('proxy_to_clsi', 1, { path: action, status: 'start' })
+    try {
+      const { stream, response } = await fetchStreamWithResponse(url.href, {
+        method: req.method,
+        signal: AbortSignal.timeout(60 * 1000),
+        headers: persistenceOptions.headers,
+      })
+      if (req.destroyed) {
+        // The client has disconnected already, avoid trying to write into the broken connection.
+        Metrics.inc('proxy_to_clsi', 1, {
+          path: action,
+          status: 'req-aborted',
+        })
+        return
+      }
+      Metrics.inc('proxy_to_clsi', 1, {
+        path: action,
+        status: response.status,
+      })
+
+      for (const key of ['Content-Length', 'Content-Type']) {
+        if (response.headers.has(key)) {
+          res.setHeader(key, response.headers.get(key))
+        }
+      }
+      res.writeHead(response.status)
+      await pipeline(stream, res)
+      timer.labels.status = 'success'
+      timer.done()
+    } catch (err) {
+      const reqAborted = Boolean(req.destroyed)
+      const status = reqAborted ? 'req-aborted-late' : 'error'
+      timer.labels.status = status
+      const duration = timer.done()
+      Metrics.inc('proxy_to_clsi', 1, { path: action, status })
+      const streamingStarted = Boolean(res.headersSent)
+      if (!streamingStarted) {
+        if (err instanceof RequestFailedError) {
+          res.sendStatus(err.response.status)
+        } else {
+          res.sendStatus(500)
+        }
+      }
+      if (
+        streamingStarted &&
+        reqAborted &&
+        (err.code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+          err.code === 'ERR_STREAM_UNABLE_TO_PIPE')
+      ) {
+        // Ignore noisy spurious error
+        return
+      }
+      if (
+        err instanceof RequestFailedError &&
+        ['sync-to-code', 'sync-to-pdf', 'output-file'].includes(action)
+      ) {
+        // Ignore noisy error
+        // https://github.com/overleaf/internal/issues/15201
+        return
+      }
+      logger.warn(
+        {
+          err,
+          projectId,
+          url,
+          action,
+          reqAborted,
+          streamingStarted,
+          duration,
+        },
+        'CLSI proxy error'
+      )
+    }
+  },
+
   async wordCount(req, res) {
     const { params, query } = parseReq(req, wordCountSchema)
     const projectId = params.Project_id
@@ -582,199 +671,38 @@ const _CompileController = {
   },
 }
 
-async function _downloadFromClsi(
-  projectIdOrSubmissionId,
-  userId,
-  editorId,
-  buildId,
-  file,
-  clsiServerId,
-  action,
+async function _getPersistenceOptions(
   req,
-  res
+  projectId,
+  compileGroup,
+  compileBackendClass
 ) {
-  const { compileBackendClass } =
-    await CompileManager.promises.getProjectCompileLimits(
-      projectIdOrSubmissionId
+  const { clsiserverid } = req.query
+  const userId = SessionManager.getLoggedInUserId(req)
+  if (clsiserverid && typeof clsiserverid === 'string') {
+    return {
+      qs: { clsiserverid, compileGroup, compileBackendClass },
+      headers: {},
+    }
+  } else {
+    const clsiServerId = await ClsiCookieManager.promises.getServerId(
+      projectId,
+      userId,
+      compileGroup,
+      compileBackendClass
     )
-  const url = getOutputZipURL(
-    projectIdOrSubmissionId,
-    userId,
-    buildId,
-    compileBackendClass,
-    clsiServerId
-  )
-  return await _proxyToClsi(
-    url,
-    projectIdOrSubmissionId,
-    userId,
-    editorId,
-    buildId,
-    file,
-    action,
-    req,
-    res
-  )
-}
-
-async function _downloadFromClsiNginx(
-  projectIdOrSubmissionId,
-  userId,
-  editorId,
-  buildId,
-  file,
-  clsiServerId,
-  action,
-  req,
-  res
-) {
-  const url = getOutputFileURL(
-    projectIdOrSubmissionId,
-    userId,
-    buildId,
-    file,
-    clsiServerId
-  )
-  return await _proxyToClsi(
-    url,
-    projectIdOrSubmissionId,
-    userId,
-    editorId,
-    buildId,
-    file,
-    action,
-    req,
-    res
-  )
-}
-
-async function _proxyToClsi(
-  url,
-  projectIdOrSubmissionId,
-  userId,
-  editorId,
-  buildId,
-  file,
-  action,
-  req,
-  res
-) {
-  const timer = new Metrics.Timer(
-    'proxy_to_clsi',
-    1,
-    { path: action },
-    [0, 100, 1000, 2000, 5000, 10000, 15000, 20000, 30000, 45000, 60000]
-  )
-  Metrics.inc('proxy_to_clsi', 1, { path: action, status: 'start' })
-  const ac = new AbortController()
-  let timeout = setTimeout(() => ac.abort(), 10_000)
-  try {
-    const { stream, response } = await fetchStreamWithResponse(url.href, {
-      method: req.method,
-      signal: ac.signal,
-    })
-    if (req.destroyed) {
-      // The client has disconnected already, avoid trying to write into the broken connection.
-      Metrics.inc('proxy_to_clsi', 1, {
-        path: action,
-        status: 'req-aborted',
-      })
-      stream.destroy(new Error('user aborted the request'))
-      return
+    return {
+      qs: { compileGroup, compileBackendClass },
+      headers: clsiServerId
+        ? {
+            Cookie: new Cookie({
+              key: Settings.clsiCookie.key,
+              value: clsiServerId,
+            }).cookieString(),
+          }
+        : {},
     }
-    Metrics.inc('proxy_to_clsi', 1, {
-      path: action,
-      status: response.status,
-    })
-
-    for (const key of ['Content-Length', 'Content-Type']) {
-      if (response.headers.has(key)) {
-        res.setHeader(key, response.headers.get(key))
-      }
-    }
-
-    // Downloads can take a while on a slow connection, increase timeouts to 10min
-    const TEN_MINUTES_IN_MS = 10 * 60 * 1000
-    res.setTimeout(TEN_MINUTES_IN_MS)
-    clearTimeout(timeout)
-    timeout = setTimeout(() => ac.abort(), TEN_MINUTES_IN_MS)
-
-    // Disable buffering in nginx
-    res.setHeader('X-Accel-Buffering', 'no')
-
-    res.writeHead(response.status)
-    await pipeline(stream, res)
-    timer.labels.status = 'success'
-    timer.done()
-  } catch (err) {
-    if (canTryClsiCacheFallback(req, res, editorId, file, action, err)) {
-      await ClsiCacheController._downloadFromCacheWithParams(
-        req,
-        res,
-        projectIdOrSubmissionId,
-        `${editorId}-${buildId}`,
-        file
-      )
-      return
-    }
-    const reqAborted = Boolean(req.destroyed)
-    const status = reqAborted ? 'req-aborted-late' : 'error'
-    timer.labels.status = status
-    const duration = timer.done()
-    Metrics.inc('proxy_to_clsi', 1, { path: action, status })
-    const streamingStarted = Boolean(res.headersSent)
-    if (!streamingStarted) {
-      if (err instanceof RequestFailedError) {
-        res.status(err.response.status).end()
-      } else {
-        res.status(500).end()
-      }
-    }
-    if (
-      streamingStarted &&
-      reqAborted &&
-      (err.code === 'ERR_STREAM_PREMATURE_CLOSE' ||
-        err.code === 'ERR_STREAM_UNABLE_TO_PIPE')
-    ) {
-      // Ignore noisy spurious error
-      return
-    }
-    if (err instanceof RequestFailedError) {
-      // Ignore noisy error: https://github.com/overleaf/internal/issues/15201
-      return
-    }
-    logger.warn(
-      {
-        err,
-        projectId: projectIdOrSubmissionId,
-        userId,
-        url,
-        action,
-        reqAborted,
-        streamingStarted,
-        duration,
-      },
-      'CLSI proxy error'
-    )
-  } finally {
-    clearTimeout(timeout)
   }
-}
-
-function canTryClsiCacheFallback(req, res, editorId, file, action, err) {
-  const reqAborted = Boolean(req.destroyed)
-  const streamingStarted = Boolean(res.headersSent)
-  return (
-    action === 'output-file' &&
-    err instanceof RequestFailedError &&
-    err.response.status === 404 &&
-    !streamingStarted &&
-    !reqAborted &&
-    editorId &&
-    // clsi-cache only has a small subset of files available outside the tar-ball.
-    // The ClsiCacheHandler will validate the filename again.
-    ClsiCacheHandler.isAllowedFilename(file)
-  )
 }
 
 const CompileController = {
@@ -785,10 +713,9 @@ const CompileController = {
   downloadPdf: expressify(_CompileController.downloadPdf), //
   compileAndDownloadPdf: expressify(_CompileController.compileAndDownloadPdf),
   deleteAuxFiles: expressify(_CompileController.deleteAuxFiles),
-  getOutputZipFromClsi: expressify(_CompileController.getOutputZipFromClsi),
   getFileFromClsi: expressify(_CompileController.getFileFromClsi),
-  getFileForSubmissionFromClsi: expressify(
-    _CompileController.getFileForSubmissionFromClsi
+  getFileFromClsiWithoutUser: expressify(
+    _CompileController.getFileFromClsiWithoutUser
   ),
   proxySyncPdf: expressify(_CompileController.proxySyncPdf),
   proxySyncCode: expressify(_CompileController.proxySyncCode),
@@ -797,6 +724,8 @@ const CompileController = {
   _getSafeProjectName: _CompileController._getSafeProjectName,
   _getSplitTestOptions,
   _getUserIdForCompile: _CompileController._getUserIdForCompile,
+  _proxyToClsi: _CompileController._proxyToClsi,
+  _proxyToClsiWithLimits: _CompileController._proxyToClsiWithLimits,
 }
 
 export default CompileController

--- a/services/web/test/unit/src/Compile/CompileController.test.mjs
+++ b/services/web/test/unit/src/Compile/CompileController.test.mjs
@@ -5,13 +5,12 @@ import MockResponse from '../helpers/MockResponse.mjs'
 import { Headers } from 'node-fetch'
 import { ReadableString } from '@overleaf/stream-utils'
 import { RequestFailedError } from '@overleaf/fetch-utils'
-import { asZodError } from '@overleaf/validation-tools/testUtils.js'
 
 const modulePath = '../../../../app/src/Features/Compile/CompileController.mjs'
 
 describe('CompileController', function () {
   beforeEach(async function (ctx) {
-    ctx.user_id = 'aaaaaaaaaaaaaaaaaaaaaaaa'
+    ctx.user_id = 'wat'
     ctx.user = {
       _id: ctx.user_id,
       email: 'user@example.com',
@@ -20,16 +19,10 @@ describe('CompileController', function () {
         compileTimeout: 100,
       },
     }
-    ctx.ClsiCacheController = {
-      _downloadFromCacheWithParams: sinon.stub().resolves(),
-    }
     ctx.CompileManager = {
       promises: {
         compile: sinon.stub(),
-        getProjectCompileLimits: sinon.stub().resolves({
-          compileBackendClass: 'c3d',
-          compileGroup: 'standard',
-        }),
+        getProjectCompileLimits: sinon.stub(),
         syncTeX: sinon.stub(),
       },
     }
@@ -46,8 +39,7 @@ describe('CompileController', function () {
     ctx.settings = {
       apis: {
         clsi: {
-          url: 'http://clsi.example.com:3013',
-          downloadHost: 'http://clsi.example.com:8080',
+          url: 'http://clsi.example.com',
           submissionBackendClass: 'c3d',
         },
         clsi_priority: {
@@ -96,12 +88,6 @@ describe('CompileController', function () {
       pipeline: ctx.pipeline,
     }))
 
-    ctx.Metrics = {
-      inc: sinon.stub(),
-      Timer: sinon.stub().returns({ done: sinon.stub(), labels: {} }),
-    }
-    vi.doMock('@overleaf/metrics', () => ({ default: ctx.Metrics }))
-
     vi.doMock('@overleaf/settings', () => ({
       default: ctx.settings,
     }))
@@ -114,12 +100,26 @@ describe('CompileController', function () {
       }),
     }))
 
-    vi.doMock(
-      '../../../../app/src/Features/Compile/ClsiCacheController',
-      () => ({
-        default: ctx.ClsiCacheController,
-      })
-    )
+    vi.doMock('../../../../app/src/Features/Project/ProjectLocator', () => ({
+      default: (ctx.ProjectLocator = {
+        promises: {
+          findRootDoc: sinon.stub(),
+        },
+      }),
+    }))
+
+    vi.doMock('@overleaf/metrics', () => ({
+      default: (ctx.Metrics = {
+        inc: sinon.stub(),
+        Timer: class {
+          constructor() {
+            this.labels = {}
+          }
+
+          done() {}
+        },
+      }),
+    }))
 
     vi.doMock('../../../../app/src/Features/Compile/CompileManager', () => ({
       default: ctx.CompileManager,
@@ -177,10 +177,7 @@ describe('CompileController', function () {
     ctx.CompileController = (await import(modulePath)).default
     ctx.projectId = 'abc123def456abc123def456'
     ctx.build_id = '18fbe9e7564-30dcb2f71250c690'
-    ctx.next = sinon.stub().callsFake(err => {
-      // Flag unexpected next calls.
-      throw err
-    })
+    ctx.next = sinon.stub()
     ctx.req = new MockRequest(vi)
     ctx.res = new MockResponse(vi)
     ctx.res = new MockResponse(vi)
@@ -233,7 +230,7 @@ describe('CompileController', function () {
               ],
               outputFilesArchive: {
                 path: 'output.zip',
-                url: `/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.zip`,
+                url: `/project/${ctx.projectId}/user/wat/build/${ctx.build_id}/output/output.zip`,
                 type: 'zip',
               },
               pdfDownloadDomain: 'https://compiles.overleaf.test',
@@ -278,7 +275,7 @@ describe('CompileController', function () {
               ],
               outputFilesArchive: {
                 path: 'output.zip',
-                url: `/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.zip`,
+                url: `/project/${ctx.projectId}/user/wat/build/${ctx.build_id}/output/output.zip`,
                 type: 'zip',
               },
               outputUrlPrefix: '/zone/b',
@@ -308,12 +305,10 @@ describe('CompileController', function () {
             isAutoCompile: false,
             compileFromClsiCache: true,
             populateClsiCache: true,
-            compileFromHistory: false,
             enablePdfCaching: false,
             fileLineErrors: false,
             stopOnFirstError: false,
             editorId: undefined,
-            rootResourcePath: undefined,
           }
         )
       })
@@ -330,7 +325,7 @@ describe('CompileController', function () {
             outputFiles: ctx.outputFiles,
             outputFilesArchive: {
               path: 'output.zip',
-              url: `/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.zip`,
+              url: `/project/${ctx.projectId}/user/wat/build/${ctx.build_id}/output/output.zip`,
               type: 'zip',
             },
           })
@@ -352,12 +347,10 @@ describe('CompileController', function () {
             isAutoCompile: true,
             compileFromClsiCache: true,
             populateClsiCache: true,
-            compileFromHistory: false,
             enablePdfCaching: false,
             fileLineErrors: false,
             stopOnFirstError: false,
             editorId: undefined,
-            rootResourcePath: undefined,
           }
         )
       })
@@ -377,13 +370,11 @@ describe('CompileController', function () {
             isAutoCompile: false,
             compileFromClsiCache: true,
             populateClsiCache: true,
-            compileFromHistory: false,
             enablePdfCaching: false,
             draft: true,
             fileLineErrors: false,
             stopOnFirstError: false,
             editorId: undefined,
-            rootResourcePath: undefined,
           }
         )
       })
@@ -403,36 +394,10 @@ describe('CompileController', function () {
             isAutoCompile: false,
             compileFromClsiCache: true,
             populateClsiCache: true,
-            compileFromHistory: false,
             enablePdfCaching: false,
             fileLineErrors: false,
             stopOnFirstError: false,
             editorId: 'the-editor-id',
-            rootResourcePath: undefined,
-          }
-        )
-      })
-    })
-    describe('with a rootResourcePath', function () {
-      beforeEach(async function (ctx) {
-        ctx.req.body = { rootResourcePath: 'foo.tex' }
-        await ctx.CompileController.compile(ctx.req, ctx.res, ctx.next)
-      })
-
-      it('should pass the rootResourcePath to the compiler', function (ctx) {
-        ctx.CompileManager.promises.compile.should.have.been.calledWith(
-          ctx.projectId,
-          ctx.user_id,
-          {
-            isAutoCompile: false,
-            compileFromClsiCache: true,
-            populateClsiCache: true,
-            compileFromHistory: false,
-            enablePdfCaching: false,
-            fileLineErrors: false,
-            stopOnFirstError: false,
-            editorId: undefined,
-            rootResourcePath: 'foo.tex',
           }
         )
       })
@@ -524,25 +489,27 @@ describe('CompileController', function () {
 
   describe('downloadPdf', function () {
     beforeEach(function (ctx) {
-      ctx.clsiServerId = 'clsi-server-1'
-      ctx.req.params = {
-        Project_id: ctx.projectId,
-        build_id: ctx.build_id,
-      }
-      ctx.req.query = { clsiserverid: ctx.clsiServerId }
-      ctx.req.session = {}
+      ctx.CompileController._proxyToClsi = sinon.stub().resolves()
+      ctx.req.params = { Project_id: ctx.projectId }
       ctx.project = { name: 'test namè; 1' }
       ctx.ProjectGetter.promises.getProject = sinon.stub().resolves(ctx.project)
+      ctx.ProjectLocator.promises.findRootDoc = sinon
+        .stub()
+        .resolves({ element: null, path: null, folder: null })
     })
 
-    describe('logged-in', function () {
+    describe('when downloading for embedding', function () {
       beforeEach(async function (ctx) {
         await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
       })
 
       it('should look up the project', function (ctx) {
         ctx.ProjectGetter.promises.getProject
-          .calledWith(ctx.projectId, { name: 1 })
+          .calledWith(ctx.projectId, {
+            name: 1,
+            rootDoc_id: 1,
+            rootFolder: 1,
+          })
           .should.equal(true)
       })
 
@@ -561,22 +528,36 @@ describe('CompileController', function () {
       })
 
       it('should proxy the PDF from the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.pdf?clsiserverid=${ctx.clsiServerId}`
-        )
+        ctx.CompileController._proxyToClsi
+          .calledWith(
+            ctx.projectId,
+            'output-file',
+            `/project/${ctx.projectId}/user/${ctx.user_id}/output/output.pdf`,
+            {},
+            ctx.req,
+            ctx.res
+          )
+          .should.equal(true)
       })
     })
 
-    describe('anon', function () {
+    describe('when a build-id is provided', function () {
       beforeEach(async function (ctx) {
-        ctx.SessionManager.getLoggedInUserId.returns(null)
+        ctx.req.params.build_id = ctx.build_id
         await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
       })
 
-      it('should proxy the PDF from the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/build/${ctx.build_id}/output/output.pdf?clsiserverid=${ctx.clsiServerId}`
-        )
+      it('should proxy the PDF from the CLSI, with a build-id', function (ctx) {
+        ctx.CompileController._proxyToClsi
+          .calledWith(
+            ctx.projectId,
+            'output-file',
+            `/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.pdf`,
+            {},
+            ctx.req,
+            ctx.res
+          )
+          .should.equal(true)
       })
     })
 
@@ -591,8 +572,9 @@ describe('CompileController', function () {
       })
       it('should return 500', async function (ctx) {
         await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
-        expect(ctx.res.status).toBeCalledWith(429)
-        ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
+        // should it be 429 instead?
+        expect(ctx.res.sendStatus).toBeCalledWith(500)
+        ctx.CompileController._proxyToClsi.should.not.have.been.called
       })
     })
 
@@ -602,111 +584,123 @@ describe('CompileController', function () {
       })
       it('should return 500', async function (ctx) {
         await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
-        expect(ctx.res.status).toBeCalledWith(500)
-        ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
-      })
-    })
-  })
-
-  describe('getOutputZipFromClsi', function () {
-    beforeEach(function (ctx) {
-      ctx.clsiServerId = 'clsi-server-1'
-      ctx.req.params = {
-        Project_id: ctx.projectId,
-        build_id: ctx.build_id,
-      }
-      ctx.req.query = { clsiserverid: ctx.clsiServerId }
-      ctx.req.session = {}
-      ctx.project = { name: 'test namè; 1' }
-      ctx.ProjectGetter.promises.getProject = sinon.stub().resolves(ctx.project)
-    })
-
-    describe('free user', function () {
-      beforeEach(async function (ctx) {
-        await ctx.CompileController.getOutputZipFromClsi(
-          ctx.req,
-          ctx.res,
-          ctx.next
-        )
-      })
-
-      it('should look up the project', function (ctx) {
-        ctx.ProjectGetter.promises.getProject
-          .calledWith(ctx.projectId, { name: 1 })
-          .should.equal(true)
-      })
-
-      it('should set the content-type of the response to application/zip', function (ctx) {
-        expect(ctx.res.contentType).toBeCalledWith('application/zip')
-      })
-
-      it('should set the content-disposition header with a safe version of the project name', function (ctx) {
-        expect(ctx.res.headers['Content-Disposition']).toEqual(
-          'attachment; filename="test_namè__1-output.zip"'
-        )
-      })
-
-      it('should proxy the PDF from the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          `${ctx.settings.apis.clsi.url}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.zip?compileBackendClass=c3d&clsiserverid=${ctx.clsiServerId}`
-        )
+        expect(ctx.res.sendStatus).toBeCalledWith(500)
+        ctx.CompileController._proxyToClsi.should.not.have.been.called
       })
     })
 
-    describe('premium user', function () {
-      beforeEach(async function (ctx) {
-        ctx.CompileManager.promises.getProjectCompileLimits = sinon
-          .stub()
-          .resolves({
-            compileGroup: 'priority',
-            compileBackendClass: 'c4d',
+    describe('when project has a root doc', function () {
+      beforeEach(function (ctx) {
+        ctx.project.rootDoc_id = 'doc-id'
+        ctx.ProjectLocator.promises.findRootDoc = sinon.stub().resolves({
+          element: { name: 'week01_slides.tex' },
+          path: null,
+          folder: null,
+        })
+      })
+
+      describe('when downloading for embedding', function () {
+        beforeEach(async function (ctx) {
+          await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
+        })
+
+        it('should set the content-disposition header with a safe version of the root doc name', function (ctx) {
+          expect(ctx.res.setContentDisposition).toBeCalledWith('inline', {
+            filename: 'week01_slides.pdf',
           })
-        await ctx.CompileController.getOutputZipFromClsi(
-          ctx.req,
-          ctx.res,
-          ctx.next
-        )
+        })
       })
 
-      it('should proxy the PDF from the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          `${ctx.settings.apis.clsi.url}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.zip?compileBackendClass=c4d&clsiserverid=${ctx.clsiServerId}`
-        )
+      describe('when downloading as attachment', function () {
+        beforeEach(async function (ctx) {
+          ctx.req.query = { popupDownload: 'true' }
+          await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
+        })
+
+        it('should set the content-disposition header with a safe version of the root doc name', function (ctx) {
+          expect(ctx.res.setContentDisposition).toBeCalledWith('attachment', {
+            filename: 'week01_slides.pdf',
+          })
+        })
+      })
+
+      describe('when root doc name has special characters', function () {
+        beforeEach(async function (ctx) {
+          ctx.ProjectLocator.promises.findRootDoc = sinon.stub().resolves({
+            element: { name: 'test namè; 1.tex' },
+            path: null,
+            folder: null,
+          })
+          await ctx.CompileController.downloadPdf(ctx.req, ctx.res, ctx.next)
+        })
+
+        it('should sanitize the root doc name', function (ctx) {
+          expect(ctx.res.setContentDisposition).toBeCalledWith('inline', {
+            filename: 'test_namè__1.pdf',
+          })
+        })
       })
     })
   })
 
-  describe('getFileForSubmissionFromClsi', function () {
+  describe('getFileFromClsiWithoutUser', function () {
     beforeEach(function (ctx) {
       ctx.submission_id = 'sub-1234'
-      ctx.clsiServerId = 'clsi-server-1'
       ctx.file = 'output.pdf'
       ctx.req.params = {
-        submissionId: ctx.submission_id,
+        submission_id: ctx.submission_id,
         build_id: ctx.build_id,
         file: ctx.file,
       }
-      ctx.req.query = { clsiserverid: ctx.clsiServerId }
+      ctx.req.body = {}
+      ctx.expected_url = `/project/${ctx.submission_id}/build/${ctx.build_id}/output/${ctx.file}`
+      ctx.CompileController._proxyToClsiWithLimits = sinon.stub()
     })
 
-    describe('proxy to CLSI with correct URL', function () {
+    describe('without limits specified', function () {
       beforeEach(async function (ctx) {
-        await ctx.CompileController.getFileForSubmissionFromClsi(
+        await ctx.CompileController.getFileFromClsiWithoutUser(
           ctx.req,
           ctx.res,
           ctx.next
         )
       })
 
-      it('should proxy to CLSI with correct URL', function (ctx) {
-        const expectedUrl = `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.submission_id}/build/${ctx.build_id}/output/${ctx.file}?clsiserverid=${ctx.clsiServerId}`
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          expectedUrl
+      it('should proxy to CLSI with correct URL and default limits', function (ctx) {
+        ctx.CompileController._proxyToClsiWithLimits.should.have.been.calledWith(
+          ctx.submission_id,
+          'output-file',
+          ctx.expected_url,
+          {},
+          { compileGroup: 'standard', compileBackendClass: 'c3d' }
+        )
+      })
+    })
+
+    describe('with limits specified', function () {
+      beforeEach(function (ctx) {
+        ctx.req.body = { compileTimeout: 600, compileGroup: 'special' }
+        ctx.CompileController.getFileFromClsiWithoutUser(
+          ctx.req,
+          ctx.res,
+          ctx.next
+        )
+      })
+
+      it('should proxy to CLSI with correct URL and specified limits', function (ctx) {
+        ctx.CompileController._proxyToClsiWithLimits.should.have.been.calledWith(
+          ctx.submission_id,
+          'output-file',
+          ctx.expected_url,
+          {},
+          {
+            compileGroup: 'special',
+            compileBackendClass: 'c3d',
+          }
         )
       })
     })
   })
-
   describe('proxySyncCode', function () {
     let file, line, column, imageName, editorId, buildId, clsiServerId
 
@@ -807,148 +801,157 @@ describe('CompileController', function () {
     })
   })
 
-  describe('getFileFromClsi', function () {
+  describe('_proxyToClsi', function () {
     beforeEach(function (ctx) {
-      ctx.clsiServerId = 'clsi-server-1'
-      ctx.req.params = {
-        Project_id: ctx.projectId,
-        build_id: ctx.build_id,
-        file: 'output.blg',
+      ctx.req.method = 'mock-method'
+      ctx.req.headers = {
+        Mock: 'Headers',
+        Range: '123-456',
+        'If-Range': 'abcdef',
+        'If-Modified-Since': 'Mon, 15 Dec 2014 15:23:56 GMT',
       }
-      ctx.req.query = { clsiserverid: ctx.clsiServerId }
-      ctx.req.session = {}
-      ctx.req.method = 'GET'
     })
 
-    describe('when the output.blg exists', function () {
-      beforeEach(async function (ctx) {
-        await ctx.CompileController.getFileFromClsi(ctx.req, ctx.res, ctx.next)
-      })
+    describe('old pdf viewer', function () {
+      describe('user with standard priority', function () {
+        beforeEach(async function (ctx) {
+          ctx.CompileManager.promises.getProjectCompileLimits = sinon
+            .stub()
+            .resolves({
+              compileGroup: 'standard',
+              compileBackendClass: 'c3d',
+            })
+          await ctx.CompileController._proxyToClsi(
+            ctx.projectId,
+            'output-file',
+            (ctx.url = '/test'),
+            { query: 'foo' },
+            ctx.req,
+            ctx.res,
+            ctx.next
+          )
+        })
 
-      it('should open a request to the CLSI download host with compile limits', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.blg?clsiserverid=${ctx.clsiServerId}`
-        )
-      })
+        it('should open a request to the CLSI', function (ctx) {
+          ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
+            `${ctx.settings.apis.clsi.url}${ctx.url}?compileGroup=standard&compileBackendClass=c3d&query=foo`
+          )
+        })
 
-      it('should pass the response stream on to the client', function (ctx) {
-        ctx.pipeline.should.have.been.calledWith(ctx.clsiStream, ctx.res)
-      })
-    })
-
-    describe('when the output.blg traverses up', function () {
-      beforeEach(async function (ctx) {
-        ctx.req.params.file = '../output.blg'
-        ctx.next = sinon.stub()
-        await ctx.CompileController.getFileFromClsi(ctx.req, ctx.res, ctx.next)
-      })
-
-      it('should reject the request', function (ctx) {
-        ctx.next.should.have.been.calledWithMatch({
-          name: 'InvalidParamsError',
-          zodError: asZodError({
-            code: 'custom',
-            path: ['params', 'file'],
-            message: 'path traversal detected',
-          }),
+        it('should pass the request on to the client', function (ctx) {
+          ctx.pipeline.should.have.been.calledWith(ctx.clsiStream, ctx.res)
         })
       })
 
-      it('should not open a request to CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
-      })
-    })
+      describe('user with priority compile', function () {
+        beforeEach(async function (ctx) {
+          ctx.CompileManager.promises.getProjectCompileLimits = sinon
+            .stub()
+            .resolves({
+              compileGroup: 'priority',
+              compileBackendClass: 'c4d',
+            })
+          await ctx.CompileController._proxyToClsi(
+            ctx.projectId,
+            'output-file',
+            (ctx.url = '/test'),
+            {},
+            ctx.req,
+            ctx.res,
+            ctx.next
+          )
+        })
 
-    describe('when the buildId traverses up', function () {
-      beforeEach(async function (ctx) {
-        ctx.req.params.build_id = '../..'
-        ctx.next = sinon.stub()
-        await ctx.CompileController.getFileFromClsi(ctx.req, ctx.res, ctx.next)
-      })
-
-      it('should reject the request', function (ctx) {
-        ctx.next.should.have.been.calledWithMatch({
-          name: 'InvalidParamsError',
-          zodError: asZodError({
-            origin: 'string',
-            code: 'invalid_format',
-            format: 'regex',
-            pattern: '/^[0-9a-f]+-[0-9a-f]+$/',
-            path: ['params', 'build_id'],
-            message: 'invalid buildId',
-          }),
+        it('should open a request to the CLSI', function (ctx) {
+          ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
+            `${ctx.settings.apis.clsi.url}${ctx.url}?compileGroup=priority&compileBackendClass=c4d`
+          )
         })
       })
 
-      it('should not open a request to CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
-      })
-    })
-
-    describe('when the output.blg does not exist', function () {
-      beforeEach(async function (ctx) {
-        ctx.editorId = '0e546f78-928e-4e8a-b5ea-3136ccf1dc53'
-        ctx.req.query = {
-          clsiserverid: ctx.clsiServerId,
-          editorId: ctx.editorId,
-        }
-        ctx.clsiURL = `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.blg?clsiserverid=${ctx.clsiServerId}`
-        ctx.fetchUtils.fetchStreamWithResponse.rejects(
-          new RequestFailedError(
-            ctx.clsiURL,
-            { method: 'GET' },
-            { status: 404 }
+      describe('user with standard priority via query string', function () {
+        beforeEach(async function (ctx) {
+          ctx.req.query = { compileGroup: 'standard' }
+          ctx.CompileManager.promises.getProjectCompileLimits = sinon
+            .stub()
+            .resolves({
+              compileGroup: 'standard',
+              compileBackendClass: 'c3d',
+            })
+          await ctx.CompileController._proxyToClsi(
+            ctx.projectId,
+            'output-file',
+            (ctx.url = '/test'),
+            {},
+            ctx.req,
+            ctx.res,
+            ctx.next
           )
-        )
-        await ctx.CompileController.getFileFromClsi(ctx.req, ctx.res, ctx.next)
-      })
+        })
 
-      it('should open a request to the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          ctx.clsiURL
-        )
-      })
-
-      it('should fallback to clsi-cache', function (ctx) {
-        ctx.ClsiCacheController._downloadFromCacheWithParams.should.have.been.calledWith(
-          ctx.req,
-          ctx.res,
-          ctx.projectId,
-          `${ctx.editorId}-${ctx.build_id}`,
-          'output.blg'
-        )
-      })
-    })
-
-    describe('when the output.stderr does not exist', function () {
-      beforeEach(async function (ctx) {
-        ctx.req.params.file = 'output.stderr'
-        ctx.editorId = '0e546f78-928e-4e8a-b5ea-3136ccf1dc53'
-        ctx.req.query = {
-          clsiserverid: ctx.clsiServerId,
-          editorId: ctx.editorId,
-        }
-        ctx.clsiURL = `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/user/${ctx.user_id}/build/${ctx.build_id}/output/output.stderr?clsiserverid=${ctx.clsiServerId}`
-        ctx.fetchUtils.fetchStreamWithResponse.rejects(
-          new RequestFailedError(
-            ctx.clsiURL,
-            { method: 'GET' },
-            { status: 404 }
+        it('should open a request to the CLSI', function (ctx) {
+          ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
+            `${ctx.settings.apis.clsi.url}${ctx.url}?compileGroup=standard&compileBackendClass=c3d`
           )
-        )
-        await ctx.CompileController.getFileFromClsi(ctx.req, ctx.res, ctx.next)
+        })
+
+        it('should pass the request on to the client', function (ctx) {
+          ctx.pipeline.should.have.been.calledWith(ctx.clsiStream, ctx.res)
+        })
       })
 
-      it('should open a request to the CLSI', function (ctx) {
-        ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-          ctx.clsiURL
-        )
+      describe('user with non-existent priority via query string', function () {
+        beforeEach(async function (ctx) {
+          ctx.req.query = { compileGroup: 'foobar' }
+          ctx.CompileManager.promises.getProjectCompileLimits = sinon
+            .stub()
+            .resolves({
+              compileGroup: 'standard',
+              compileBackendClass: 'c3d',
+            })
+          await ctx.CompileController._proxyToClsi(
+            ctx.projectId,
+            'output-file',
+            (ctx.url = '/test'),
+            {},
+            ctx.req,
+            ctx.res,
+            ctx.next
+          )
+        })
+
+        it('should proxy to the standard url', function (ctx) {
+          ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
+            `${ctx.settings.apis.clsi.url}${ctx.url}?compileGroup=standard&compileBackendClass=c3d`
+          )
+        })
       })
 
-      it('should not fallback to clsi-cache', function (ctx) {
-        ctx.ClsiCacheController._downloadFromCacheWithParams.should.not.have
-          .been.called
-        expect(ctx.res.statusCode).to.equal(404)
+      describe('user with build parameter via query string', function () {
+        beforeEach(async function (ctx) {
+          ctx.CompileManager.promises.getProjectCompileLimits = sinon
+            .stub()
+            .resolves({
+              compileGroup: 'standard',
+              compileBackendClass: 'c3d',
+            })
+          ctx.req.query = { build: 1234 }
+          await ctx.CompileController._proxyToClsi(
+            ctx.projectId,
+            'output-file',
+            (ctx.url = '/test'),
+            {},
+            ctx.req,
+            ctx.res,
+            ctx.next
+          )
+        })
+
+        it('should proxy to the standard url without the build parameter', function (ctx) {
+          ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
+            `${ctx.settings.apis.clsi.url}${ctx.url}?compileGroup=standard&compileBackendClass=c3d`
+          )
+        })
       })
     })
   })
@@ -974,28 +977,21 @@ describe('CompileController', function () {
   })
 
   describe('compileAndDownloadPdf', function () {
-    const clsiServerId = 'server-1'
-
     beforeEach(function (ctx) {
       ctx.req = {
         params: {
           project_id: ctx.projectId,
         },
-        method: 'GET',
       }
+      ctx.downloadPath = `/project/${ctx.projectId}/build/123/output/output.pdf`
       ctx.CompileManager.promises.compile.resolves({
         status: 'success',
-        outputFiles: [{ path: 'output.pdf' }],
-        clsiServerId,
-        buildId: ctx.build_id,
+        outputFiles: [{ path: 'output.pdf', url: ctx.downloadPath }],
       })
+      ctx.CompileController._proxyToClsi = sinon.stub()
       ctx.res = {
         send: () => {},
         sendStatus: sinon.stub(),
-        writeHead: sinon.stub(),
-        setHeader: sinon.stub(),
-        setTimeout: sinon.stub(),
-        headersSent: false,
       }
     })
 
@@ -1006,11 +1002,28 @@ describe('CompileController', function () {
         .should.equal(true)
     })
 
-    it('should proxy the PDF from the CLSI with the correct URL', async function (ctx) {
+    it('should proxy the res to the clsi with correct url', async function (ctx) {
       await ctx.CompileController.compileAndDownloadPdf(ctx.req, ctx.res)
-      ctx.fetchUtils.fetchStreamWithResponse.should.have.been.calledWith(
-        `${ctx.settings.apis.clsi.downloadHost}/project/${ctx.projectId}/build/${ctx.build_id}/output/output.pdf?clsiserverid=${clsiServerId}`
+      sinon.assert.calledWith(
+        ctx.CompileController._proxyToClsi,
+        ctx.projectId,
+        'output-file',
+        ctx.downloadPath,
+        {},
+        ctx.req,
+        ctx.res
       )
+
+      ctx.CompileController._proxyToClsi
+        .calledWith(
+          ctx.projectId,
+          'output-file',
+          ctx.downloadPath,
+          {},
+          ctx.req,
+          ctx.res
+        )
+        .should.equal(true)
     })
 
     it('should not download anything on compilation failures', async function (ctx) {
@@ -1021,19 +1034,17 @@ describe('CompileController', function () {
         ctx.next
       )
       ctx.res.sendStatus.should.have.been.calledWith(500)
-      ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
+      ctx.CompileController._proxyToClsi.should.not.have.been.called
     })
 
     it('should not download anything on missing pdf', async function (ctx) {
       ctx.CompileManager.promises.compile.resolves({
         status: 'success',
         outputFiles: [],
-        clsiServerId,
-        buildId: ctx.build_id,
       })
       await ctx.CompileController.compileAndDownloadPdf(ctx.req, ctx.res)
       ctx.res.sendStatus.should.have.been.calledWith(500)
-      ctx.fetchUtils.fetchStreamWithResponse.should.not.have.been.called
+      ctx.CompileController._proxyToClsi.should.not.have.been.called
     })
   })
 


### PR DESCRIPTION
## Description

When a project contains multiple `.tex` files (e.g. `week01_slides.tex`, 
`week02_slides.tex`) and the user switches the main document and compiles, 
the "Download PDF" button always saves the file as `ProjectName.pdf` instead 
of using the compiled file's name.

This PR names the downloaded PDF after the project's configured main document 
(`rootDoc_id`) instead of the project title, with a fallback to the current 
project-name behavior.

### Changes:
- Extend the project fetch in `downloadPdf` to include `rootDoc_id` and `rootFolder`
- Add `_getPdfDownloadFilename` helper that resolves the main document name via 
  `ProjectLocator.promises.findRootDoc`, strips the extension, and applies the 
  same `_getSafeProjectName` sanitization
- Falls back to project name if `rootDoc_id` is unset or the doc can't be found
- Error handling: if `findRootDoc` throws, falls back gracefully to project name

| Before | After |
|--------|-------|
| Main doc = `week01_slides.tex` → downloads as `MyProject.pdf` | → `week01_slides.pdf` |
| Main doc = `week02_slides.tex` → downloads as `MyProject.pdf` | → `week02_slides.pdf` |
| No root doc set → `MyProject.pdf` | → `MyProject.pdf` (unchanged) |

## Related issues / Pull Requests

Related to #1142

## Contributor Agreement

I have read and agree to the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLSef79XH3mb7yIiMzZw-yALEegS-wyFetvjTiNBfZvf_IHD2KA/viewform).

## Testing

- All 43 unit tests pass (including 3 new cases for root doc filename, 
  attachment download, and special character sanitization)
- Tested locally via Docker dev environment
- No frontend changes required

## Files changed

- `services/web/app/src/Features/Compile/CompileController.mjs`
- `services/web/test/unit/src/Compile/CompileController.test.mjs`