### PR TITLE
Fix Japanese IME emoji composition

### DIFF
--- a/services/web/frontend/js/features/ide-react/components/global-toasts.tsx
+++ b/services/web/frontend/js/features/ide-react/components/global-toasts.tsx
@@ -6,6 +6,7 @@ import { debugConsole } from '@/utils/debugging'
 import importOverleafModules from '../../../../macros/import-overleaf-module.macro'
 import { OLToastContainer } from '@/shared/components/ol/ol-toast-container'
 import clipboardToastGenerators from '@/features/source-editor/components/clipboard-toasts'
+import compositionToastGenerators from '@/features/source-editor/components/composition-toasts'
 import importDocumentFeedbackToastGenerators from '@/features/project-list/components/new-project-button/import-document-feedback-toast'
 import exportDocumentToastGenerators from '@/features/ide-react/components/toolbar/export-document-toasts'
 import pythonOutputToastGenerators from '@/features/ide-react/components/editor/python/python-output-toasts'
@@ -30,6 +31,7 @@ type GlobalToastGenerator = (
 const GENERATOR_LIST: GlobalToastGeneratorEntry[] = [
   ...moduleGenerators.flat(),
   ...clipboardToastGenerators,
+  ...compositionToastGenerators,
   ...importDocumentFeedbackToastGenerators,
   ...exportDocumentToastGenerators,
   ...pythonOutputToastGenerators,

--- a/services/web/frontend/js/features/source-editor/components/composition-toasts.tsx
+++ b/services/web/frontend/js/features/source-editor/components/composition-toasts.tsx
@@ -1,0 +1,31 @@
+import { GlobalToastGeneratorEntry } from '@/features/ide-react/components/global-toasts'
+import { useTranslation } from 'react-i18next'
+
+const CompositionDiscardedToast = ({ text }: { text?: string }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <p>
+        <b>{t('input_not_applied')}</b>
+      </p>
+      {text ? <p>“{text}”</p> : null}
+      {t('input_discarded_due_to_simultaneous_edit')}
+    </>
+  )
+}
+
+const generators: GlobalToastGeneratorEntry[] = [
+  {
+    key: 'composition:discarded',
+    generator: ({ text }: { text?: string }) => ({
+      content: <CompositionDiscardedToast text={text} />,
+      type: 'warning',
+      autoHide: true,
+      delay: 8000,
+      isDismissible: true,
+    }),
+  },
+]
+
+export default generators

--- a/services/web/frontend/js/features/source-editor/extensions/composition.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/composition.ts
@@ -1,0 +1,192 @@
+import {
+  ChangeSpec,
+  EditorState,
+  StateEffect,
+  StateField,
+  Transaction,
+} from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { TextOperation } from 'overleaf-editor-core'
+import { diffChars } from 'diff'
+import { DocumentContainer } from '@/features/ide-react/editor/document-container'
+import { ShareLatexOTShareDoc } from '../../../../../types/share-doc'
+
+/*
+ * Composition-aware syncing for the Overleaf <-> OT bridge.
+ *
+ * The OT layer cannot represent non-BMP characters (emoji etc.), so they are
+ * replaced with the Unicode replacement character. The naive approach — scrub
+ * them out of every transaction as it arrives — fires *during* an active IME
+ * composition and rewrites the composed range, which breaks the browser IME
+ * (candidate cycling stops, Backspace dies, a garbled glyph appears).
+ *
+ * Instead, while a composition is active we let the editor hold the real
+ * composed text (including a previewed emoji) and pause forwarding changes to
+ * the OT layer. The `compositionField` flag below is read by the state-level
+ * extensions that forward to OT (`filter-characters`, `realtime`,
+ * `history-ot`'s `updateSender`) so they become no-ops during composition.
+ *
+ * When the composition ends we scrub the committed text (code-point aware, so
+ * one emoji collapses to a single replacement char) and reconcile the OT layer
+ * once, by diffing the OT snapshot against the scrubbed editor text.
+ */
+
+// Matches characters the OT layer cannot represent:
+// - astral-plane code points (emoji etc.) — matched as a single code point
+//   thanks to the `u` flag, so one emoji collapses to one replacement char
+// - lone UTF-16 surrogates
+// - NUL
+export const BAD_CHARS_PATTERN = '[\\u{10000}-\\u{10FFFF}]|[\\0\\uD800-\\uDFFF]'
+export const BAD_CHARS_REPLACEMENT_CHAR = '�'
+
+const badCharsRegExp = () => new RegExp(BAD_CHARS_PATTERN, 'gu')
+
+export const scrubBadChars = (text: string) =>
+  text.replace(badCharsRegExp(), BAD_CHARS_REPLACEMENT_CHAR)
+
+const setCompositionEffect = StateEffect.define<boolean>()
+
+const compositionField = StateField.define<boolean>({
+  create() {
+    return false
+  },
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setCompositionEffect)) {
+        value = effect.value
+      }
+    }
+    return value
+  },
+})
+
+/**
+ * Whether an IME composition is currently active. Readable from state-level
+ * extensions (transaction filters/extenders) that have no access to the view.
+ * Defaults to false if the field isn't installed.
+ */
+export const isComposing = (state: EditorState): boolean =>
+  state.field(compositionField, false)
+
+// Build a TextOperation transforming `from` into `to`, for history-OT.
+const buildTextOperation = (from: string, to: string): TextOperation => {
+  const op = new TextOperation()
+  for (const part of diffChars(from, to)) {
+    if (part.removed) {
+      op.remove(part.value.length)
+    } else if (part.added) {
+      op.insert(part.value)
+    } else {
+      op.retain(part.value.length)
+    }
+  }
+  return op
+}
+
+// Apply the diff between `from` and `to` to a sharejs-text-ot shareDoc, using
+// the same insert/del calls the normal local-change path uses.
+const applySharejsDiff = (
+  shareDoc: ShareLatexOTShareDoc,
+  from: string,
+  to: string
+) => {
+  let pos = 0
+  for (const part of diffChars(from, to)) {
+    if (part.removed) {
+      shareDoc.del(pos, part.value.length)
+    } else if (part.added) {
+      shareDoc.insert(pos, part.value)
+      pos += part.value.length
+    } else {
+      pos += part.value.length
+    }
+  }
+}
+
+// Minimal change specs to replace each bad-char run in the editor with a single
+// replacement char.
+const computeScrubChanges = (state: EditorState): ChangeSpec[] => {
+  const text = state.doc.toString()
+  const changes: ChangeSpec[] = []
+  for (const match of text.matchAll(badCharsRegExp())) {
+    const from = match.index!
+    changes.push({
+      from,
+      to: from + match[0].length,
+      insert: BAD_CHARS_REPLACEMENT_CHAR,
+    })
+  }
+  return changes
+}
+
+// If CodeMirror hasn't finished flushing the committed composition by the time
+// we run, retry on the next frame for up to this many frames before giving up.
+const MAX_RECONCILE_FRAMES = 60
+
+export const compositionSync = (currentDoc: DocumentContainer) => {
+  const reconcile = (view: EditorView) => {
+    if (!currentDoc.doc) {
+      // Nothing to reconcile against; just clear the flag.
+      view.dispatch({ effects: setCompositionEffect.of(false) })
+      return
+    }
+
+    const otText = currentDoc.getSnapshot() ?? ''
+    const editorText = view.state.doc.toString()
+    const target = scrubBadChars(editorText)
+
+    // 1. Reconcile the OT layer to the scrubbed text in a single operation. The
+    //    composition flag is still set, so the normal forwarding paths stay
+    //    paused and won't double-submit.
+    if (otText !== target) {
+      if (currentDoc.isHistoryOT()) {
+        currentDoc.historyOTShareDoc.submitOp([
+          buildTextOperation(otText, target),
+        ])
+      } else {
+        applySharejsDiff(
+          currentDoc.shareDoc as ShareLatexOTShareDoc,
+          otText,
+          target
+        )
+      }
+    }
+
+    // 2. Replace any bad chars in the editor with the replacement char. Still
+    //    flagged as composing, so this is not forwarded to the OT layer.
+    const scrubChanges = computeScrubChanges(view.state)
+    if (scrubChanges.length) {
+      view.dispatch({
+        changes: scrubChanges,
+        annotations: Transaction.addToHistory.of(false),
+      })
+    }
+
+    // 3. Clear the composition flag, resuming normal syncing.
+    view.dispatch({ effects: setCompositionEffect.of(false) })
+  }
+
+  const scheduleReconcile = (view: EditorView, framesLeft: number) => {
+    requestAnimationFrame(() => {
+      if (view.composing && framesLeft > 0) {
+        // CodeMirror hasn't finished flushing the committed composition yet, or
+        // a new composition started; wait another frame.
+        scheduleReconcile(view, framesLeft - 1)
+      } else {
+        reconcile(view)
+      }
+    })
+  }
+
+  return [
+    compositionField,
+    EditorView.domEventHandlers({
+      compositionstart(_event, view) {
+        view.dispatch({ effects: setCompositionEffect.of(true) })
+      },
+      compositionend(_event, view) {
+        scheduleReconcile(view, MAX_RECONCILE_FRAMES)
+      },
+    }),
+  ]
+}

--- a/services/web/frontend/js/features/source-editor/extensions/composition.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/composition.ts
@@ -1,15 +1,14 @@
 import {
   ChangeSpec,
+  EditorSelection,
   EditorState,
   StateEffect,
   StateField,
   Transaction,
 } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { TextOperation } from 'overleaf-editor-core'
 import { diffChars } from 'diff'
 import { DocumentContainer } from '@/features/ide-react/editor/document-container'
-import { ShareLatexOTShareDoc } from '../../../../../types/share-doc'
 
 /*
  * Composition-aware syncing for the Overleaf <-> OT bridge.
@@ -26,9 +25,17 @@ import { ShareLatexOTShareDoc } from '../../../../../types/share-doc'
  * extensions that forward to OT (`filter-characters`, `realtime`,
  * `history-ot`'s `updateSender`) so they become no-ops during composition.
  *
- * When the composition ends we scrub the committed text (code-point aware, so
- * one emoji collapses to a single replacement char) and reconcile the OT layer
- * once, by diffing the OT snapshot against the scrubbed editor text.
+ * When the composition ends we:
+ *   1. revert the composed text out of the editor (not forwarded to OT — which
+ *      never saw it — and not added to the undo history), then
+ *   2. re-apply the scrubbed text (one emoji -> a single replacement char) as a
+ *      single *normal* edit. That edit flows through the usual local-edit path,
+ *      so it syncs to the OT layer correctly for both OT modes and is attributed
+ *      as a tracked change in review mode, and it forms a single, clean undo
+ *      step back to the pre-composition state.
+ *
+ * If a remote edit arrives while composing, we can't safely merge, so we drop
+ * the in-progress composition, resync to the snapshot, and warn the user.
  */
 
 // Matches characters the OT layer cannot represent:
@@ -68,55 +75,31 @@ const compositionField = StateField.define<boolean>({
 export const isComposing = (state: EditorState): boolean =>
   state.field(compositionField, false)
 
-// Build a TextOperation transforming `from` into `to`, for history-OT.
-const buildTextOperation = (from: string, to: string): TextOperation => {
-  const op = new TextOperation()
-  for (const part of diffChars(from, to)) {
-    if (part.removed) {
-      op.remove(part.value.length)
-    } else if (part.added) {
-      op.insert(part.value)
-    } else {
-      op.retain(part.value.length)
-    }
-  }
-  return op
-}
-
-// Apply the diff between `from` and `to` to a sharejs-text-ot shareDoc, using
-// the same insert/del calls the normal local-change path uses.
-const applySharejsDiff = (
-  shareDoc: ShareLatexOTShareDoc,
-  from: string,
-  to: string
-) => {
+// Minimal change specs transforming the editor document `from` into `to`.
+export const diffToChangeSpecs = (from: string, to: string): ChangeSpec[] => {
+  const changes: ChangeSpec[] = []
   let pos = 0
   for (const part of diffChars(from, to)) {
     if (part.removed) {
-      shareDoc.del(pos, part.value.length)
-    } else if (part.added) {
-      shareDoc.insert(pos, part.value)
+      changes.push({ from: pos, to: pos + part.value.length })
       pos += part.value.length
+    } else if (part.added) {
+      changes.push({ from: pos, insert: part.value })
     } else {
       pos += part.value.length
     }
   }
+  return changes
 }
 
-// Minimal change specs to replace each bad-char run in the editor with a single
-// replacement char.
-const computeScrubChanges = (state: EditorState): ChangeSpec[] => {
-  const text = state.doc.toString()
-  const changes: ChangeSpec[] = []
-  for (const match of text.matchAll(badCharsRegExp())) {
-    const from = match.index!
-    changes.push({
-      from,
-      to: from + match[0].length,
-      insert: BAD_CHARS_REPLACEMENT_CHAR,
+// Warn the user that their in-progress composition was discarded because a
+// collaborator edited the same location while they were composing.
+const showCompositionDiscardedToast = (text: string) => {
+  window.dispatchEvent(
+    new CustomEvent('ide:show-toast', {
+      detail: { key: 'composition:discarded', text },
     })
-  }
-  return changes
+  )
 }
 
 // If CodeMirror hasn't finished flushing the committed composition by the time
@@ -125,45 +108,78 @@ const MAX_RECONCILE_FRAMES = 60
 
 export const compositionSync = (currentDoc: DocumentContainer) => {
   const reconcile = (view: EditorView) => {
+    if (!isComposing(view.state)) {
+      // Already reconciled for this composition. Keeps this idempotent across
+      // the compositionend handler and the composing-ended fallback below.
+      return
+    }
+
+    const editor = currentDoc.cm6
+
     if (!currentDoc.doc) {
       // Nothing to reconcile against; just clear the flag.
+      if (editor) {
+        editor.remoteOpDuringComposition = false
+      }
       view.dispatch({ effects: setCompositionEffect.of(false) })
       return
     }
 
-    const otText = currentDoc.getSnapshot() ?? ''
+    const snapshot = currentDoc.getSnapshot() ?? ''
     const editorText = view.state.doc.toString()
-    const target = scrubBadChars(editorText)
+    const caret = view.state.selection.main.head
 
-    // 1. Reconcile the OT layer to the scrubbed text in a single operation. The
-    //    composition flag is still set, so the normal forwarding paths stay
-    //    paused and won't double-submit.
-    if (otText !== target) {
-      if (currentDoc.isHistoryOT()) {
-        currentDoc.historyOTShareDoc.submitOp([
-          buildTextOperation(otText, target),
-        ])
-      } else {
-        applySharejsDiff(
-          currentDoc.shareDoc as ShareLatexOTShareDoc,
-          otText,
-          target
-        )
-      }
-    }
-
-    // 2. Replace any bad chars in the editor with the replacement char. Still
-    //    flagged as composing, so this is not forwarded to the OT layer.
-    const scrubChanges = computeScrubChanges(view.state)
-    if (scrubChanges.length) {
+    // Revert the in-progress composition out of the editor. It was never added
+    // to the undo history (see the transactionExtender below) and is marked
+    // `remote` so it is not forwarded to the OT layer, which never saw it.
+    const revertChanges = diffToChangeSpecs(editorText, snapshot)
+    if (revertChanges.length) {
       view.dispatch({
-        changes: scrubChanges,
-        annotations: Transaction.addToHistory.of(false),
+        changes: revertChanges,
+        annotations: [
+          Transaction.remote.of(true),
+          Transaction.addToHistory.of(false),
+        ],
       })
     }
 
-    // 3. Clear the composition flag, resuming normal syncing.
+    if (editor?.remoteOpDuringComposition) {
+      // A collaborator edited the document while this composition was active.
+      // We buffered their change rather than disrupting the IME, but we can't
+      // safely merge the in-progress composition against it. The revert above
+      // already resynced the editor to the (remotely-updated) snapshot, so we
+      // just drop the composition and warn the user.
+      editor.remoteOpDuringComposition = false
+
+      const discardedText = diffChars(snapshot, editorText)
+        .filter(part => part.added)
+        .map(part => part.value)
+        .join('')
+      if (discardedText) {
+        showCompositionDiscardedToast(discardedText)
+      }
+
+      view.dispatch({ effects: setCompositionEffect.of(false) })
+      return
+    }
+
+    // Clear the composition flag, then re-apply the scrubbed composed text as a
+    // single normal edit. It flows through the usual local-edit path, so it
+    // syncs to the OT layer (both modes, with track-changes attribution) and is
+    // a single, clean undo step back to the pre-composition snapshot.
     view.dispatch({ effects: setCompositionEffect.of(false) })
+
+    const target = scrubBadChars(editorText)
+    const commitChanges = diffToChangeSpecs(snapshot, target)
+    if (commitChanges.length) {
+      // Restore the caret to its committed position (mapped through the scrub),
+      // so committing a composition doesn't jump the cursor to the line start.
+      const commitCaret = scrubBadChars(editorText.slice(0, caret)).length
+      view.dispatch({
+        changes: commitChanges,
+        selection: EditorSelection.cursor(commitCaret),
+      })
+    }
   }
 
   const scheduleReconcile = (view: EditorView, framesLeft: number) => {
@@ -178,15 +194,45 @@ export const compositionSync = (currentDoc: DocumentContainer) => {
     })
   }
 
+  let wasComposing = false
+
   return [
     compositionField,
+    // Keep the raw composition out of the undo history. The scrubbed result is
+    // re-applied as a single undoable edit at compositionend (see reconcile),
+    // so undo returns cleanly to the pre-composition state instead of leaving
+    // an orphaned, un-undoable replacement char behind.
+    EditorState.transactionExtender.of(tr => {
+      if (
+        tr.docChanged &&
+        isComposing(tr.startState) &&
+        !tr.annotation(Transaction.remote)
+      ) {
+        return { annotations: Transaction.addToHistory.of(false) }
+      }
+      return null
+    }),
     EditorView.domEventHandlers({
       compositionstart(_event, view) {
+        if (currentDoc.cm6) {
+          currentDoc.cm6.remoteOpDuringComposition = false
+        }
         view.dispatch({ effects: setCompositionEffect.of(true) })
       },
       compositionend(_event, view) {
         scheduleReconcile(view, MAX_RECONCILE_FRAMES)
       },
+    }),
+    // Fallback: if a composition ends without a compositionend event (e.g. blur
+    // or the IME aborting), reconcile once CodeMirror reports it is no longer
+    // composing, so the bridge can't get stuck paused. Idempotent with the
+    // compositionend handler above (reconcile no-ops if already reconciled).
+    EditorView.updateListener.of(update => {
+      const composingNow = update.view.composing
+      if (wasComposing && !composingNow && isComposing(update.state)) {
+        scheduleReconcile(update.view, MAX_RECONCILE_FRAMES)
+      }
+      wasComposing = composingNow
     }),
   ]
 }

--- a/services/web/frontend/js/features/source-editor/extensions/filter-characters.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/filter-characters.ts
@@ -1,23 +1,26 @@
 import { ChangeSpec, EditorState, Transaction } from '@codemirror/state'
-
-const BAD_CHARS_REGEXP = /[\0\uD800-\uDFFF]/g
-const BAD_CHARS_REPLACEMENT_CHAR = '\uFFFD'
+import { isComposing, scrubBadChars } from './composition'
 
 /**
  * A custom extension that replaces input characters in a Unicode range with a replacement character.
+ *
+ * Skipped while an IME composition is active: rewriting the composed range
+ * mid-composition breaks the browser IME. Composed text is scrubbed once when
+ * the composition ends (see `composition.ts`).
  */
 export const filterCharacters = () => {
   return EditorState.transactionFilter.of(tr => {
-    if (tr.docChanged && !tr.annotation(Transaction.remote)) {
+    if (
+      tr.docChanged &&
+      !tr.annotation(Transaction.remote) &&
+      !isComposing(tr.startState)
+    ) {
       const changes: ChangeSpec[] = []
 
       tr.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
         const text = inserted.toString()
 
-        const newText = text.replaceAll(
-          BAD_CHARS_REGEXP,
-          BAD_CHARS_REPLACEMENT_CHAR
-        )
+        const newText = scrubBadChars(text)
 
         if (newText !== text) {
           changes.push({

--- a/services/web/frontend/js/features/source-editor/extensions/history-ot.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/history-ot.ts
@@ -22,6 +22,7 @@ import {
   TrackedDeletes,
   trackedDeletesFromState,
 } from '@/features/source-editor/utils/tracked-deletes'
+import { isComposing } from './composition'
 
 export const historyOT = (currentDoc: DocumentContainer) => {
   const trackedChanges =
@@ -244,7 +245,15 @@ const trackChangesUserIdState = StateField.define<string | null>({
 })
 
 const updateSender = EditorState.transactionExtender.of(tr => {
-  if (!tr.docChanged || tr.annotation(Transaction.remote)) {
+  // While an IME composition is active, pause submitting ops to the OT layer.
+  // The composed text (which may include a non-BMP emoji that the OT core
+  // cannot represent) is reconciled once when the composition ends (see
+  // `composition.ts`).
+  if (
+    !tr.docChanged ||
+    tr.annotation(Transaction.remote) ||
+    isComposing(tr.startState)
+  ) {
     return {}
   }
 

--- a/services/web/frontend/js/features/source-editor/extensions/index.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/index.ts
@@ -25,6 +25,7 @@ import { spelling } from './spelling'
 import { symbolPalette } from './symbol-palette'
 import { search } from './search'
 import { filterCharacters } from './filter-characters'
+import { compositionSync } from './composition'
 import { keybindings } from './keybindings'
 import { bracketMatching, bracketSelection } from './bracket-matching'
 import { verticalOverflow } from './vertical-overflow'
@@ -119,6 +120,7 @@ export const createExtensions = (options: Record<string, any>): Extension[] => [
   }),
   keymaps,
   goToLinePanel(),
+  compositionSync(options.currentDoc.currentDocument),
   filterCharacters(),
 
   // NOTE: `autoComplete` needs to be before `keybindings` so that arrow key handling

--- a/services/web/frontend/js/features/source-editor/extensions/realtime.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/realtime.ts
@@ -25,6 +25,7 @@ import {
 } from 'overleaf-editor-core'
 import { rangesUpdatedEffect, setTrackChangesUserId } from './history-ot'
 import { trackedDeletesFromState } from '@/features/source-editor/utils/tracked-deletes'
+import { isComposing } from './composition'
 
 /*
  * Integrate CodeMirror 6 with the real-time system, via ShareJS.
@@ -67,7 +68,10 @@ export const realtime = (
 
     return {
       update(update) {
-        if (update.docChanged) {
+        // While an IME composition is active, pause forwarding to the OT layer.
+        // The composed text (which may include an emoji preview) is reconciled
+        // once when the composition ends (see `composition.ts`).
+        if (update.docChanged && !isComposing(update.state)) {
           editor.handleUpdateFromCM(update.transactions, currentDoc.ranges)
         }
       },

--- a/services/web/frontend/js/features/source-editor/extensions/realtime.ts
+++ b/services/web/frontend/js/features/source-editor/extensions/realtime.ts
@@ -113,6 +113,10 @@ type OTAdapter = {
 export class EditorFacade extends EventEmitter {
   private otAdapter: OTAdapter | null
   public events: EventEmitter
+  // Set by the OT adapters when a remote op arrives while an IME composition is
+  // active (its editor echo is buffered rather than applied). Read by the
+  // composition reconcile in `composition.ts` to decide it cannot safely merge.
+  public remoteOpDuringComposition = false
 
   constructor(public view: EditorView) {
     super()
@@ -215,11 +219,21 @@ class ShareLatexOTAdapter {
     }
 
     const onInsert = (pos: number, text: string) => {
+      if (isComposing(this.editor.view.state)) {
+        // Buffer the remote echo during composition so the IME isn't disrupted
+        // (see composition.ts). The OT snapshot has already advanced.
+        this.editor.remoteOpDuringComposition = true
+        return
+      }
       this.editor.cmInsert(pos, text, 'remote')
       check()
     }
 
     const onDelete = (pos: number, text: string) => {
+      if (isComposing(this.editor.view.state)) {
+        this.editor.remoteOpDuringComposition = true
+        return
+      }
       this.editor.cmDelete(pos, text, 'remote')
       check()
     }
@@ -355,6 +369,12 @@ class HistoryOTAdapter {
   }
 
   onRemoteOp(operations: EditOperation[]) {
+    if (isComposing(this.editor.view.state)) {
+      // Buffer the remote echo during composition so the IME isn't disrupted
+      // (see composition.ts). The OT snapshot has already advanced.
+      this.editor.remoteOpDuringComposition = true
+      return
+    }
     const trackedDeletes = trackedDeletesFromState(this.editor.view.state)
     const changes: ChangeSpec[] = []
     let trackedChangesUpdated = false

--- a/services/web/locales/en.json
+++ b/services/web/locales/en.json
@@ -1233,6 +1233,8 @@
   "initiator": "Initiator",
   "inline": "Inline",
   "inline_math": "Inline math",
+  "input_discarded_due_to_simultaneous_edit": "A collaborator edited the same location while you were typing, so your in-progress input was discarded. Please type it again.",
+  "input_not_applied": "Input not applied",
   "inr_discount_modal_info": "Get document history, track changes, additional collaborators, and more at Purchasing Power Parity prices.",
   "inr_discount_modal_title": "70% off all Overleaf premium plans for users in India",
   "inr_discount_offer_plans_page_banner": "__flag__ <b>Great news!</b> We’ve applied a <b>70% discount</b> to premium plans for our users in India. Check out the new lower prices below.",

--- a/services/web/test/frontend/features/source-editor/extensions/composition-sync.test.ts
+++ b/services/web/test/frontend/features/source-editor/extensions/composition-sync.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { compositionSync } from '../../../../../frontend/js/features/source-editor/extensions/composition'
+
+const nextFrame = () =>
+  new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+
+// Integration tests that drive the compositionSync extension with synthetic
+// composition events. Real IME composition can't be simulated in jsdom, but the
+// extension's reconcile is triggered by compositionstart/compositionend DOM
+// events plus a small stub of DocumentContainer, which we can drive here. This
+// notably covers the remote-edit-during-composition path, which can't be tested
+// manually by a single user (switching focus commits the composition).
+describe('compositionSync', function () {
+  const setup = (snapshot: string, initialDoc = snapshot) => {
+    const cm6 = { remoteOpDuringComposition: false }
+    const currentDoc = {
+      doc: {},
+      cm6,
+      getSnapshot: () => snapshot,
+    }
+    const state = EditorState.create({
+      doc: initialDoc,
+      extensions: [compositionSync(currentDoc as any)],
+    })
+    const view = new EditorView({ state })
+    return { view, cm6 }
+  }
+
+  // Simulate composing `text` at the end of the document, optionally running
+  // `onComposing` (e.g. to flag a remote edit) before the composition ends.
+  const compose = async (
+    view: EditorView,
+    text: string,
+    onComposing?: () => void
+  ) => {
+    view.contentDOM.dispatchEvent(new Event('compositionstart'))
+    // Insert the composed text and place the caret after it, as an IME does.
+    const at = view.state.doc.length
+    view.dispatch({
+      changes: { from: at, insert: text },
+      selection: { anchor: at + text.length },
+    })
+    onComposing?.()
+    view.contentDOM.dispatchEvent(new Event('compositionend'))
+    await nextFrame()
+    await nextFrame()
+  }
+
+  it('commits a composed emoji as a single replacement char with the caret after it', async function () {
+    const { view } = setup('abc')
+    await compose(view, '\u{1F600}')
+    expect(view.state.doc.toString()).to.equal('abc�')
+    expect(view.state.selection.main.head).to.equal(4)
+    view.destroy()
+  })
+
+  it('commits normal composed text unchanged', async function () {
+    const { view } = setup('abc')
+    await compose(view, 'にほんご')
+    expect(view.state.doc.toString()).to.equal('abcにほんご')
+    expect(view.state.selection.main.head).to.equal('abcにほんご'.length)
+    view.destroy()
+  })
+
+  it('discards the composition and resyncs to the snapshot when a remote edit arrives mid-composition', async function () {
+    // The snapshot advanced to 'Xabc' (a collaborator inserted 'X') while the
+    // user was composing 'YZ' on top of the original 'abc'.
+    const { view, cm6 } = setup('Xabc', 'abc')
+
+    let toast: { key?: string; text?: string } | null = null
+    const listener = (event: Event) => {
+      toast = (event as CustomEvent).detail
+    }
+    window.addEventListener('ide:show-toast', listener)
+
+    await compose(view, 'YZ', () => {
+      cm6.remoteOpDuringComposition = true
+    })
+
+    window.removeEventListener('ide:show-toast', listener)
+
+    expect(view.state.doc.toString()).to.equal('Xabc')
+    expect(cm6.remoteOpDuringComposition).to.equal(false)
+    expect(toast).to.not.equal(null)
+    expect(toast!.key).to.equal('composition:discarded')
+    expect(toast!.text).to.equal('YZ')
+    view.destroy()
+  })
+})

--- a/services/web/test/frontend/features/source-editor/extensions/composition.test.ts
+++ b/services/web/test/frontend/features/source-editor/extensions/composition.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai'
+import { EditorState } from '@codemirror/state'
+import {
+  scrubBadChars,
+  diffToChangeSpecs,
+} from '../../../../../frontend/js/features/source-editor/extensions/composition'
+
+describe('composition', function () {
+  describe('scrubBadChars', function () {
+    it('collapses one emoji to a single replacement char', function () {
+      expect(scrubBadChars('\u{1F600}')).to.equal('�')
+    })
+
+    it('collapses each emoji among surrounding text', function () {
+      expect(scrubBadChars('a\u{1F600}b\u{1F601}c')).to.equal('a�b�c')
+    })
+
+    it('replaces a lone high surrogate', function () {
+      expect(scrubBadChars('\uD800')).to.equal('�')
+    })
+
+    it('replaces a lone low surrogate', function () {
+      expect(scrubBadChars('x\uDC00y')).to.equal('x�y')
+    })
+
+    it('replaces a NUL character', function () {
+      expect(scrubBadChars('a\0b')).to.equal('a�b')
+    })
+
+    it('leaves BMP text unchanged', function () {
+      expect(scrubBadChars('Hello にほんご')).to.equal('Hello にほんご')
+    })
+
+    it('is idempotent', function () {
+      expect(scrubBadChars(scrubBadChars('a\u{1F600}b'))).to.equal('a�b')
+    })
+  })
+
+  describe('diffToChangeSpecs', function () {
+    // Apply the change specs to a `from` document and assert they yield `to`.
+    const apply = (from: string, to: string) => {
+      const state = EditorState.create({ doc: from })
+      return state
+        .update({ changes: diffToChangeSpecs(from, to) })
+        .state.doc.toString()
+    }
+
+    it('transforms by appending', function () {
+      expect(apply('hello', 'hello world')).to.equal('hello world')
+    })
+
+    it('transforms by deleting', function () {
+      expect(apply('hello world', 'hello')).to.equal('hello')
+    })
+
+    it('transforms by replacing mid-string', function () {
+      expect(apply('abc', 'aXc')).to.equal('aXc')
+    })
+
+    it('resyncs an editor holding a composition to a remotely-edited snapshot', function () {
+      // editor had "ねこ" composed at the end; snapshot received remote "X" at the start
+      expect(apply('abcねこ', 'Xabc')).to.equal('Xabc')
+    })
+
+    it('is a no-op when already equal', function () {
+      expect(apply('same', 'same')).to.equal('same')
+    })
+  })
+})

--- a/services/web/test/frontend/features/source-editor/extensions/filter-characters.test.ts
+++ b/services/web/test/frontend/features/source-editor/extensions/filter-characters.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai'
+import { EditorState, Transaction } from '@codemirror/state'
+import { filterCharacters } from '../../../../../frontend/js/features/source-editor/extensions/filter-characters'
+
+describe('filterCharacters', function () {
+  // Insert `text` into a (optionally non-empty) document configured with the
+  // filterCharacters extension, and return the resulting document text.
+  const applyInsert = (
+    text: string,
+    opts: { remote?: boolean; doc?: string } = {}
+  ) => {
+    const doc = opts.doc ?? ''
+    const state = EditorState.create({
+      doc,
+      extensions: [filterCharacters()],
+    })
+    const tr = state.update({
+      changes: { from: doc.length, insert: text },
+      annotations: opts.remote ? Transaction.remote.of(true) : undefined,
+    })
+    return tr.state.doc.toString()
+  }
+
+  it('replaces an emoji (surrogate pair) with a single replacement char', function () {
+    expect(applyInsert('\u{1F600}')).to.equal('�')
+  })
+
+  it('replaces two emoji with two replacement chars', function () {
+    expect(applyInsert('\u{1F600}\u{1F601}')).to.equal('��')
+  })
+
+  it('preserves text surrounding an emoji', function () {
+    expect(applyInsert('a\u{1F600}b')).to.equal('a�b')
+  })
+
+  it('replaces a lone high surrogate', function () {
+    expect(applyInsert('\uD800')).to.equal('�')
+  })
+
+  it('replaces a lone low surrogate', function () {
+    expect(applyInsert('x\uDC00y')).to.equal('x�y')
+  })
+
+  it('replaces a NUL character', function () {
+    expect(applyInsert('\0')).to.equal('�')
+  })
+
+  it('leaves ASCII text unchanged', function () {
+    expect(applyInsert('hello world')).to.equal('hello world')
+  })
+
+  it('leaves BMP CJK text unchanged', function () {
+    expect(applyInsert('にほんご')).to.equal('にほんご')
+  })
+
+  it('does not scrub remote changes', function () {
+    expect(applyInsert('\u{1F600}', { remote: true })).to.equal('\u{1F600}')
+  })
+
+  it('is idempotent on already-scrubbed text', function () {
+    expect(applyInsert('�')).to.equal('�')
+  })
+})


### PR DESCRIPTION
# Fix Japanese IME breaking on emoji conversion candidates in the source editor

## Background: Japanese input and IMEs (context for reviewers)

If you don't use a CJK input method, this bug is hard to picture, so here's the necessary background.

**Japanese can't be typed one keystroke per character.**
A writer types the pronunciation (in romaji or kana) and the operating system's **IME (Input Method Editor)** converts it into the intended characters.
Crucially, the same pronunciation maps to many possible words/characters (homophones): for example the sound "kao" (かお) can become 顔 ("face"), カオ, かお, and others, so the IME shows a **candidate list** and the user picks one.

**Composition.**
While the user is choosing, the text is uncommitted and shown inline with an underline as a live preview (the "composition").
The user presses **Space** to cycle through candidates and **Enter** to commit the chosen one.
Until commit, this text is provisional and the application is expected to leave it alone and let the browser/IME manage it.
Rewriting the composing text out from under the IME cancels or corrupts the composition.

**Where emoji come in.**
Most IMEs offer emojis as conversion candidates.
For example, "kao" can convert to a 😄 face emoji.
Emoji are non-BMP (Basic Multilingual Plane) characters (UTF-16 surrogate pairs).

**Normal, correct behaviour:**
type `kao` -> underlined preview かお -> press Space to cycle 顔 / 😄 / カオ / ... -> press Enter to commit.
Space keeps cycling, nothing disturbs the preview, and after commit ordinary editing (Backspace, etc.) works.

## The bug

In the Overleaf source (Code) editor, the moment an emoji candidate appears in the list (while still composing, before commit), the IME breaks:

- a garbled, doubled `U+FFFD` (? inside a diamond) replacement glyph appears in place of the preview;
- Space stops cycling candidates;
- Backspace sometimes stops working;
- after committing, the caret jumps backwards by several characters instead of staying after the inserted character.

So Japanese users **can't enter emoji nor the ordinary candidates that appears after an emoji**.
This is reproducible across browsers, and only inside the editor.
(Although I can say it's reproducible, I cannot tell you the exact steps to replicate with the exact string, because IMEs "learn" the user's input and change the candidates' order as the user uses it.)

I understand that not allowing non-BMP characters is a design choice ([Inserting emojis in LaTeX documents on Overleaf](https://www.overleaf.com/learn/latex/Questions/Inserting_emojis_in_LaTeX_documents_on_Overleaf)); However, it should not mean that IMEs cannot work with Overleaf.

### Root cause

Overleaf's OT (operational-transform) layer cannot represent non-BMP characters, so the editor scrubs them to `U+FFFD`.
The problem is that this scrub runs **while the IME is still composing**:

- `filter-characters.ts` installs an `EditorState.transactionFilter` that replaces surrogate code units with `U+FFFD` and appends a corrective transaction rewriting the composed range, which desyncs the browser IME.
    Because that rewrite happens while the browser is still composing, the browser IME and CodeMirror's composition tracking are left desynced and stuck active, so Space stops cycling candidates and, after commit, Backspace does nothing (both swallowed by the dangling composition) until a click elsewhere or a clean non-emoji commit resets it.
  Its regex matches per UTF-16 code unit, so one emoji becomes two `U+FFFD`.
  That corrective transaction sets no new selection, so the caret is left wherever the disrupted composition leaves it (before the committed text, sometimes several characters back) rather than after it.
- The editor cannot hold a non-BMP character even transiently: history-OT (`overleaf-editor-core`) throws on non-BMP in `TextOperation`/`InsertOp`, and `checkConsistency` compares the editor against the OT snapshot on every change. (sharejs-text-ot doesn't reject, but the server sanitises surrogates per code unit.)
- Two independent local -> OT submission paths forward composition changes with no composition awareness: the realtime `ViewPlugin` (sharejs op submission + consistency check + auto-compile trigger) and history-OT's `updateSender` `transactionExtender`.

## Approach: composition-aware sync

I first tried containing the fix to the character filter alone, deferring the scrub until after composition so the IME isn't disturbed.
But because the editor can't hold the emoji even transiently (above), deferring only traded the IME breakage for an "Out of sync" error.
The fix has to coordinate across the forwarding paths, not live in one filter.

While an IME composition is active, let the editor hold the **real** composed text (including a previewed emoji) and **pause every local -> OT path**.
A `compositionField` flag is read by `filter-characters`, the realtime `ViewPlugin`, and history-OT's `updateSender`, so they become no-ops during composition.
The IME is therefore never disrupted while cycling candidates.

On `compositionend`:

1. **Revert** the composed text out of the editor. This revert is not forwarded to the OT layer (which never saw it) and not added to the undo history.
2. **Re-apply** the scrubbed text as a single *normal* edit. The code-point-aware, so one emoji collapses to a **single** `U+FFFD`. Because it is an ordinary local edit, it:
   - syncs to the OT layer through the usual path, so it is correct for **both** OT modes and attributed as a **tracked change** in review mode, and
   - is a **single, clean undo step** back to the pre-composition state.

If a remote edit arrives mid-composition we can't safely merge it against the in-progress composition, so we **drop the composition, resync the editor to the snapshot, and warn the user** with a toast.
The remote echo is buffered during composition so the IME isn't visually disrupted before that point.

A fallback reconciles even if no `compositionend` event fires, so the editor <-> OT bridge can never get stuck paused.

## What this covers

- **Both OT modes** (history-OT and sharejs-text-ot): sync goes through the normal local-edit path.
- **Track changes (review mode)**: composed text is attributed correctly and positions are mapped through tracked deletes.
- **Caret position**: the re-applied edit restores the caret to its committed position (mapped through the scrub), so committing keeps the caret after the inserted character instead of jumping it backwards.
- **Undo**: one clean step; can neither strand the replacement char nor resurrect the emoji.
- **Auto-compile**: unaffected; forwarding pauses during composition and fires once after the commit.
- **Concurrent remote edits during composition**: safe (drop + resync + warn); never desyncs or corrupts the document.

## Testing

**Automated** (`services/web/test/frontend/features/source-editor/extensions/`):

- `filter-characters.test.ts`: code-point-aware scrubbing (one emoji -> one `U+FFFD`, lone surrogates, NUL, remote-skip, idempotency).
- `composition.test.ts`: the scrub helper and the diff -> change-spec helper.
- `composition-sync.test.ts`: integration tests driving synthetic composition events: emoji commit -> single `U+FFFD` with the caret preserved; normal Japanese commit; and **remote-edit-during-composition -> discard + resync + warning toast**.

**Manual** (history-OT dev environment), verified on macOS (macOS Japanese IME) and Linux (Ubuntu, fcitx5-mozc), in Chrome and Firefox:

Typing a Japanese reading, cycling to an emoji candidate, then committing:

- the IME is no longer disrupted (Space cycles, native preview shows);
- the commit yields a single `U+FFFD`;
- Backspace works;
- the caret stays in place;
- undo is clean;
- there's no "Out of sync";
- ordinary Japanese round-trips unchanged.

## Not verified / out of scope

The following were not verified:

- **PDF compilation / rendering**: the dev environment has no TeX Live, so I could not confirm that documents still compile or how a committed `U+FFFD` renders. (The change only touches editor<->OT sync, not compilation, and `U+FFFD` is a normal BMP character.)
- **Concurrent / multi-user editing during composition**: can't be triggered by a single user (switching focus commits the composition), so it is covered only by the synthetic-event integration test, not a real two-client session. To verify with real clients: two users on the same document, one composing Japanese on a line while the other edits it: the composing user keeps a stable IME and, on commit, sees the collaborator's edit plus an "Input not applied" toast.
- **sharejs-text-ot mode at runtime**: the dev environment runs history-OT. The sharejs path now goes through the same normal sync path, but was not exercised live.
- **Track changes (review mode) at runtime**: covered by reuse of the normal edit path and by reasoning, but not exercised by hand.
- **The visual (rich text) editor**: this change is for the source editor only. The visual editor was not touched, and whether it has the same bug is unknown.
- **Other IMEs**: Windows IME, Google Japanese Input, Chinese, Korean, and mobile IMEs were not tested, and composition-event timing can differ between them.
- **Pasting an emoji outside composition**: the filter now collapses it to a single `U+FFFD` (unit-tested), but this was not exercised by hand in the app.
- **Full CI**: I ran eslint, prettier, and the new frontend unit tests on the changed files, but not the full project test suite or a full type-check.

## Files changed

- `services/web/frontend/js/features/source-editor/extensions/composition.ts` **(new)**: the composition flag, scrub/diff helpers, and the compositionend reconcile.
- `services/web/frontend/js/features/source-editor/extensions/filter-characters.ts`: code-point-aware regex; skip while composing.
- `services/web/frontend/js/features/source-editor/extensions/realtime.ts`: pause OT forwarding while composing; buffer remote echoes.
- `services/web/frontend/js/features/source-editor/extensions/history-ot.ts`: pause `updateSender` while composing.
- `services/web/frontend/js/features/source-editor/extensions/index.ts`: register the extension.
- `services/web/frontend/js/features/source-editor/components/composition-toasts.tsx` **(new)** + `.../ide-react/components/global-toasts.tsx`: the "Input not applied" warning toast.
- `services/web/locales/en.json`: toast strings.
- `services/web/test/frontend/features/source-editor/extensions/{filter-characters,composition,composition-sync}.test.ts` **(new)**.

## Related issues

- **[#1234](https://github.com/overleaf/overleaf/issues/1234) "Enable to display 4-byte characters in the editor"** (open):
  the user-side report of this bug (Windows, Google/Microsoft IME). This PR fixes the input breakage, not the request to store/display 4-byte characters, so a committed emoji still becomes `U+FFFD` (because I thought this is a design choice).

## Additional notes

I used Claude code for the development, because although I have general knowledge about web processing, I am not an expert on web development nor an expert on Overleaf.
However, I believe I am a good engineer in general and tried my best to check that the implementation looks reasonable and also manually checked the behavior.

Additionally, I understand that this is a community version and is different from the officially hosted version.
However, this problem is persistent across both versions, and I hope that once this PR is accepted for the community version, it's also applied to the hosted version as well.

## Review

- [x] I have signed the Contributor License Agreement.
