### PR TITLE
Fix TeXcount handling for newcolumntype

### DIFF
--- a/services/clsi/app/js/CompileManager.js
+++ b/services/clsi/app/js/CompileManager.js
@@ -43,6 +43,8 @@ const KNOWN_LATEXMK_RULES = new Set([
 ])
 
 const LATEX_PASSES_RULES = new Set(['latex', 'lualatex', 'xelatex', 'pdflatex'])
+const TEXCOUNT_OPTIONS_FILE = '.overleaf-texcount-options'
+const TEXCOUNT_OPTIONS = '%preambleinclude \\newcolumntype [ignore,xxx]\n'
 
 function getCompileName(projectId, userId) {
   if (userId != null) {
@@ -647,7 +649,8 @@ async function _runSynctex(projectId, userId, command, opts) {
 async function wordcount(projectId, userId, filename, image) {
   logger.debug({ projectId, userId, filename, image }, 'running wordcount')
   const filePath = `$COMPILE_DIR/${filename}`
-  const command = ['texcount', '-nocol', '-inc', filePath]
+  const optionsPath = `$COMPILE_DIR/${TEXCOUNT_OPTIONS_FILE}`
+  const command = ['texcount', '-nocol', '-inc', `-opt=${optionsPath}`, filePath]
   const compileDir = getCompileDir(projectId, userId)
   const timeout = 60 * 1000
   const compileName = getCompileName(projectId, userId)
@@ -661,6 +664,18 @@ async function wordcount(projectId, userId, filename, image) {
     await fsPromises.mkdir(compileDir, { recursive: true })
   } catch (err) {
     throw OError.tag(err, 'error ensuring dir for wordcount', {
+      projectId,
+      userId,
+      filename,
+    })
+  }
+  try {
+    await fsPromises.writeFile(
+      Path.join(compileDir, TEXCOUNT_OPTIONS_FILE),
+      TEXCOUNT_OPTIONS
+    )
+  } catch (err) {
+    throw OError.tag(err, 'error writing texcount options for wordcount', {
       projectId,
       userId,
       filename,

--- a/services/clsi/test/unit/js/CompileManager.test.js
+++ b/services/clsi/test/unit/js/CompileManager.test.js
@@ -135,6 +135,7 @@ describe('CompileManager', () => {
       stat: sinon.stub(),
       readFile: sinon.stub(),
       mkdir: sinon.stub().resolves(),
+      writeFile: sinon.stub().resolves(),
       rm: sinon.stub().resolves(),
       unlink: sinon.stub().resolves(),
       rmdir: sinon.stub().resolves(),
@@ -743,7 +744,13 @@ describe('CompileManager', () => {
 
     it('should run the texcount command', ctx => {
       ctx.filePath = `$COMPILE_DIR/${ctx.filename}`
-      ctx.command = ['texcount', '-nocol', '-inc', ctx.filePath]
+      ctx.command = [
+        'texcount',
+        '-nocol',
+        '-inc',
+        '-opt=$COMPILE_DIR/.overleaf-texcount-options',
+        ctx.filePath,
+      ]
 
       expect(ctx.CommandRunner.promises.run).to.have.been.calledWith(
         `${ctx.projectId}-${ctx.userId}`,
@@ -752,6 +759,13 @@ describe('CompileManager', () => {
         ctx.image,
         ctx.timeout,
         {}
+      )
+    })
+
+    it('should write texcount options for known preamble macros', ctx => {
+      expect(ctx.fsPromises.writeFile).to.have.been.calledWith(
+        Path.join(ctx.compileDir, '.overleaf-texcount-options'),
+        '%preambleinclude \\newcolumntype [ignore,xxx]\n'
       )
     })
 


### PR DESCRIPTION
## Description

Adds a CLSI-generated TeXcount option file for word count requests so TeXcount handles `\newcolumntype` declarations in the preamble without parsing their column definitions as real math/groups.

The generated option file is written into the compile directory as `.overleaf-texcount-options` and passed to `texcount` with `-opt=$COMPILE_DIR/.overleaf-texcount-options`.

## Related issues / Pull Requests

Contributes to #1396

## Verification

- Reproduced the issue with standalone TeXcount 3.1.1: the minimal `\newcolumntype{C}{>{$}c<{$}}` document reported 8 TeXcount errors and 0 text words before the rule; with `%preambleinclude \newcolumntype [ignore,xxx]`, it reported 1 text word and no errors.
- `yarn --cwd services/clsi test:unit --run test/unit/js/CompileManager.test.js`
- `yarn --cwd services/clsi test:unit --run test/unit/js/CompileManager.test.js test/unit/js/CompileController.test.js`
- `git diff --check`

Notes: `yarn --cwd services/clsi lint` could not run in this checkout because `eslint` is not exposed on the workspace script path, and direct root ESLint invocation could not find a flat config for `services/clsi`. The full CLSI unit suite also has unrelated local failures for missing `services/clsi/app/js/DockerRunner` and an absolute `/overleaf` fixture path.

## Contributor Agreement

- [ ] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
