### PR TITLE
Fix OVERLEAF_INVITE_TOKEN_SECRET being ignored in server-ce settings

### DIFF
--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -307,7 +307,7 @@ const settings = {
 
 // This secret is used for encrypting sharing link tokens in the database
 if (process.env.OVERLEAF_INVITE_TOKEN_SECRET) {
-  module.exports.projectInviteEncryptorOptions = {
+  settings.projectInviteEncryptorOptions = {
     cipherLabel: '2026.3-v3',
     cipherPasswords: {
       '2026.3-v3': process.env.OVERLEAF_INVITE_TOKEN_SECRET,


### PR DESCRIPTION
## Description

With OVERLEAF_INVITE_TOKEN_SECRET set, the web service still logs on every boot:

Failed to initialise Link Sharing token encryption. Please ensure OVERLEAF_INVITE_TOKEN_SECRET is set.
and the new link-sharing invite flow throws Token encryption not configured.
(Email invites and legacy token link-sharing are unaffected, so it's easy to miss.)

This happens in overleaf ce 6.2.0.

<!-- Goal of the pull request -->

## Related issues / Pull Requests

<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

https://github.com/overleaf/overleaf/issues/1498

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
