### PR TITLE
Show edited timestamp on review panel comments

### DIFF
--- a/services/chat/test/acceptance/js/EditingAMessageTests.js
+++ b/services/chat/test/acceptance/js/EditingAMessageTests.js
@@ -14,6 +14,7 @@ describe('Editing a message', async function () {
     const content = 'thread message'
     const newContent = 'updated thread message'
     let messageId
+    let originalTimestamp
     beforeEach(async function () {
       projectId = new ObjectId().toString()
       userId = new ObjectId().toString()
@@ -29,6 +30,7 @@ describe('Editing a message', async function () {
       expect(message.id).to.exist
       expect(message.content).to.equal(content)
       messageId = message.id
+      originalTimestamp = message.timestamp
     })
 
     describe('without user', function () {
@@ -48,6 +50,10 @@ describe('Editing a message', async function () {
         expect(response.statusCode).to.equal(200)
         expect(threads[threadId].messages.length).to.equal(1)
         expect(threads[threadId].messages[0].content).to.equal(newContent)
+        expect(threads[threadId].messages[0].edited_at).to.exist
+        expect(threads[threadId].messages[0].timestamp).to.equal(
+          originalTimestamp
+        )
       })
     })
 
@@ -69,6 +75,10 @@ describe('Editing a message', async function () {
         expect(response.statusCode).to.equal(200)
         expect(threads[threadId].messages.length).to.equal(1)
         expect(threads[threadId].messages[0].content).to.equal(newContent)
+        expect(threads[threadId].messages[0].edited_at).to.exist
+        expect(threads[threadId].messages[0].timestamp).to.equal(
+          originalTimestamp
+        )
       })
     })
 

--- a/services/web/frontend/js/features/review-panel/components/review-panel-message.tsx
+++ b/services/web/frontend/js/features/review-panel/components/review-panel-message.tsx
@@ -73,7 +73,15 @@ export const ReviewPanelMessage: FC<{
         <div>
           <ReviewPanelEntryUser user={message.user} />
           <div className="review-panel-entry-time">
-            <FormatTimeBasedOnYear date={message.timestamp} />
+            <FormatTimeBasedOnYear
+              date={message.edited_at ?? message.timestamp}
+            />
+            {message.edited_at ? (
+              <>
+                {' '}
+                <span className="message-edited">({t('edited')})</span>
+              </>
+            ) : null}
           </div>
         </div>
 

--- a/services/web/frontend/js/features/review-panel/context/threads-context.tsx
+++ b/services/web/frontend/js/features/review-panel/context/threads-context.tsx
@@ -38,6 +38,48 @@ import { useReviewPanelViewContext } from './review-panel-view-context'
 
 export type Threads = Record<ThreadId, ReviewPanelCommentThread>
 
+type ThreadMessagePayload = ReviewPanelCommentThreadMessage & {
+  timestamp: number | string | Date
+  edited_at?: number | string | Date
+}
+
+function parseThreadMessage(
+  message: ThreadMessagePayload
+): ReviewPanelCommentThreadMessage {
+  return {
+    ...message,
+    timestamp: new Date(message.timestamp),
+    ...(message.edited_at != null
+      ? { edited_at: new Date(message.edited_at) }
+      : {}),
+  }
+}
+
+function applyMessageEdit(
+  threads: Threads | undefined,
+  threadId: ThreadId,
+  commentId: CommentId,
+  content: string
+): Threads | undefined {
+  if (!threads) {
+    return threads
+  }
+
+  const thread = threads[threadId] ?? { messages: [] }
+
+  return {
+    ...threads,
+    [threadId]: {
+      ...thread,
+      messages: thread.messages.map(message =>
+        message.id === commentId
+          ? { ...message, content, edited_at: new Date() }
+          : message
+      ),
+    },
+  }
+}
+
 export const ThreadsContext = createContext<Threads | undefined>(undefined)
 
 type ThreadsActions = {
@@ -84,7 +126,14 @@ export const ThreadsProvider: FC<React.PropsWithChildren> = ({ children }) => {
       signal: abortController.signal,
     })
       .then(data => {
-        setData(data)
+        const parsed: Threads = {}
+        for (const [threadId, thread] of Object.entries(data as Threads)) {
+          parsed[threadId as ThreadId] = {
+            ...thread,
+            messages: thread.messages.map(parseThreadMessage),
+          }
+        }
+        setData(parsed)
       })
       .catch(error => {
         debugConsole.error(error)
@@ -115,11 +164,10 @@ export const ThreadsProvider: FC<React.PropsWithChildren> = ({ children }) => {
                 ...thread,
                 messages: [
                   ...thread.messages,
-                  {
+                  parseThreadMessage({
                     ...comment,
                     user: comment.user, // TODO
-                    timestamp: new Date(comment.timestamp),
-                  },
+                  }),
                 ],
               },
             }
@@ -134,21 +182,7 @@ export const ThreadsProvider: FC<React.PropsWithChildren> = ({ children }) => {
     socket,
     'edit-message',
     useCallback((threadId: ThreadId, commentId: CommentId, content: string) => {
-      setData(value => {
-        if (value) {
-          const thread = value[threadId] ?? { messages: [] }
-
-          return {
-            ...value,
-            [threadId]: {
-              ...thread,
-              messages: thread.messages.map(message =>
-                message.id === commentId ? { ...message, content } : message
-              ),
-            },
-          }
-        }
-      })
+      setData(value => applyMessageEdit(value, threadId, commentId, content))
     }, [])
   )
 
@@ -254,10 +288,7 @@ export const ThreadsProvider: FC<React.PropsWithChildren> = ({ children }) => {
             resolved_by_user: thread.resolved_by_user,
           }
           for (const message of thread.messages) {
-            newThreadData.messages.push({
-              ...message,
-              timestamp: new Date(message.timestamp),
-            })
+            newThreadData.messages.push(parseThreadMessage(message))
           }
           newThreads[threadId as ThreadId] = newThreadData
         }
@@ -328,6 +359,7 @@ export const ThreadsProvider: FC<React.PropsWithChildren> = ({ children }) => {
           `/project/${projectId}/thread/${threadId}/messages/${commentId}/edit`,
           { body: { content } }
         )
+        setData(value => applyMessageEdit(value, threadId, commentId, content))
       },
       async deleteMessage(threadId: ThreadId, commentId: CommentId) {
         await deleteJSON(

--- a/services/web/test/frontend/features/review-panel/components/review-panel-message.test.tsx
+++ b/services/web/test/frontend/features/review-panel/components/review-panel-message.test.tsx
@@ -1,0 +1,102 @@
+import { expect } from 'chai'
+import { render, screen } from '@testing-library/react'
+import { ReviewPanelMessage } from '@/features/review-panel/components/review-panel-message'
+import { UserContext } from '@/shared/context/user-context'
+import { PermissionsContext } from '@/features/ide-react/context/permissions-context'
+import { User, UserId } from '@ol-types/user'
+import {
+  CommentId,
+  ReviewPanelCommentThreadMessage,
+  ReviewPanelUser,
+} from '@ol-types/review-panel/review-panel'
+import { formatTimeBasedOnYear } from '@/features/utils/format-date'
+
+const userId = 'aabbccddeeff00112233aabb' as UserId
+
+const currentUser: User = {
+  id: userId,
+  email: 'jane@example.com',
+  first_name: 'Jane',
+}
+
+const messageUser: ReviewPanelUser = {
+  avatar_text: 'J',
+  email: 'jane@example.com',
+  hue: 180,
+  id: userId,
+  isSelf: true,
+  name: 'Jane',
+}
+
+const permissions = {
+  read: true,
+  comment: false,
+  resolveOwnComments: false,
+  resolveAllComments: false,
+  trackedWrite: false,
+  write: false,
+  admin: false,
+  labelVersion: false,
+}
+
+function renderMessage(message: ReviewPanelCommentThreadMessage) {
+  return render(
+    <UserContext.Provider value={currentUser}>
+      <PermissionsContext.Provider value={permissions}>
+        <ReviewPanelMessage
+          message={message}
+          hasReplies={false}
+          isReply={false}
+          isThreadResolved={false}
+        />
+      </PermissionsContext.Provider>
+    </UserContext.Provider>
+  )
+}
+
+describe('<ReviewPanelMessage />', function () {
+  it('uses edited_at for the header time after a comment is edited', function () {
+    const originalTimestamp = new Date('2020-03-15T10:00:00.000Z')
+    const editedAt = new Date('2024-11-20T16:45:00.000Z')
+
+    const message: ReviewPanelCommentThreadMessage = {
+      content: 'updated comment text',
+      id: 'comment-1' as CommentId,
+      timestamp: originalTimestamp,
+      edited_at: editedAt,
+      user: messageUser,
+      user_id: userId,
+    }
+
+    renderMessage(message)
+
+    const headerTime = document.querySelector('.review-panel-entry-time')
+    expect(headerTime).to.exist
+    expect(headerTime?.textContent).to.include(formatTimeBasedOnYear(editedAt))
+    expect(headerTime?.textContent).to.not.include(
+      formatTimeBasedOnYear(originalTimestamp)
+    )
+    expect(screen.getByText('(edited)')).to.exist
+  })
+
+  it('uses the original timestamp when a comment has not been edited', function () {
+    const originalTimestamp = new Date('2020-03-15T10:00:00.000Z')
+
+    const message: ReviewPanelCommentThreadMessage = {
+      content: 'original comment text',
+      id: 'comment-2' as CommentId,
+      timestamp: originalTimestamp,
+      user: messageUser,
+      user_id: userId,
+    }
+
+    renderMessage(message)
+
+    const headerTime = document.querySelector('.review-panel-entry-time')
+    expect(headerTime).to.exist
+    expect(headerTime?.textContent).to.include(
+      formatTimeBasedOnYear(originalTimestamp)
+    )
+    expect(screen.queryByText('(edited)')).to.not.exist
+  })
+})

--- a/services/web/types/review-panel/review-panel.ts
+++ b/services/web/types/review-panel/review-panel.ts
@@ -20,6 +20,7 @@ export interface ReviewPanelCommentThreadMessage {
   content: string
   id: CommentId
   timestamp: Date
+  edited_at?: Date
   user?: ReviewPanelUser
   user_id: UserId
 }


### PR DESCRIPTION
Editing a comment stored `edited_at` but the review panel still rendered the original `timestamp`, and the live `edit-message` socket only patched content.

Show `edited_at` (with the existing "edited" label) and leave the original timestamp alone so reply order stays creation order.

Fixes #1509