### PR TITLE
fix(server-ce): keep projectInviteEncryptorOptions in exported settings

### DIFF
--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -307,7 +307,7 @@ const settings = {
 
 // This secret is used for encrypting sharing link tokens in the database
 if (process.env.OVERLEAF_INVITE_TOKEN_SECRET) {
-  module.exports.projectInviteEncryptorOptions = {
+  settings.projectInviteEncryptorOptions = {
     cipherLabel: '2026.3-v3',
     cipherPasswords: {
       '2026.3-v3': process.env.OVERLEAF_INVITE_TOKEN_SECRET,


### PR DESCRIPTION
### Problem

`server-ce/config/settings.js` assigns `projectInviteEncryptorOptions` onto `module.exports`:

```js
if (process.env.OVERLEAF_INVITE_TOKEN_SECRET) {
  module.exports.projectInviteEncryptorOptions = { ... }
}
```

but further down the same file the whole export is replaced:

```js
module.exports = settings
```

so the assignment is discarded.

### Impact

`OVERLEAF_INVITE_TOKEN_SECRET` has no effect in Community Edition. `CollaboratorsInviteHelper` then constructs `AccessTokenEncryptor` with `undefined` and every web boot logs:

```
Failed to initialise Link Sharing token encryption. Please ensure OVERLEAF_INVITE_TOKEN_SECRET is set.
```

even when the variable is set correctly, and link sharing stays broken.

Since 6.2.0 the variable is documented as required ("The application will refuse to start if the variable is missing"), so this affects every CE deployment that follows the upgrade notes.

### Reproducing

With `OVERLEAF_INVITE_TOKEN_SECRET` set on the container:

```
$ docker exec <container> printenv OVERLEAF_INVITE_TOKEN_SECRET | wc -c
45
$ docker exec -w /overleaf/services/web <container> node --input-type=module \
    -e 'import s from "@overleaf/settings"; console.log(!!s.projectInviteEncryptorOptions)'
false
```

Constructing the encryptor directly with the same value succeeds, which narrows it down to the settings file rather than the secret itself.

### Fix

Assign to `settings` - the object that is actually exported.

Verified on 6.2.0 and 6.2.2 CE images: after the change the value is picked up (`true`), the error no longer appears on boot, and link sharing works.

### Notes

The 6.2.2 release notes mention "fix OVERLEAF_INVITE_TOKEN_SECRET being ignored in settings" for Server Pro; the Community Edition config still has the ordering issue on current `main`.
